### PR TITLE
Implemented pmprosws migration functionality

### DIFF
--- a/classes/class-swsales-about.php
+++ b/classes/class-swsales-about.php
@@ -41,20 +41,6 @@ class SWSales_About {
 				</div>
 			</div>
 
-			<div class="notice notice-warning notice-large inline">
-				<h3><?php esc_html_e( 'Migrate Your Previous Sales Data', 'sitewide-sales' ); ?></h3>
-				<p><?php esc_html_e( 'We have detected data from the Sitewide Sales Add On for Paid Memberships Pro. You can migrate this data into the new Sitewide Sales plugin and maintain access to previous sales, settings, and reports. The database migration process will attempt to run in a single process, so please be patient.', 'sitewide-sales' ); ?>
-				</p>
-				<p class="submit">
-					<a href="#" class="button-primary">
-						<?php esc_html_e( 'Migrate PMPro Sitewide Sales Data', 'sitewide-sales' ); ?>
-					</a>
-					<a href="#" class="button-secondary">
-						<?php esc_html_e( 'Dismiss This Notice', 'sitewide-sales' ); ?>
-					</a>
-				</p>
-			</div>
-
 			<div class="sws-wrap">
 				<h2><?php esc_html_e( 'About Sitewide Sales', 'sitewide-sales' ); ?></h2>
 				<div class="sws-text">

--- a/modules/class-swsales-module-pmpro.php
+++ b/modules/class-swsales-module-pmpro.php
@@ -371,6 +371,7 @@ class SWSales_Module_PMPro {
 			if ( ! empty( $reports ) ) {
 				update_post_meta( $pmpro_sws_sale_id, 'swsales_banner_impressions', $reports['banner_impressions'] );
 				update_post_meta( $pmpro_sws_sale_id, 'swsales_landing_page_visits', $reports['landing_page_visits'] );
+				delete_option( 'pmpro_sws_' . $pmpro_sws_sale_id . '_tracking' );
 			}
 
 			// Update shortcodes in landing page post content and landing page template.

--- a/modules/class-swsales-module-pmpro.php
+++ b/modules/class-swsales-module-pmpro.php
@@ -248,6 +248,14 @@ class SWSales_Module_PMPro {
 			return;
 		}
 
+		if ( ! empty( $_REQUEST['swsales_pmpro_migrated_sales'] ) ) {
+			?>
+			<div class="notice notice-success notice-large inline">
+					<p><?php esc_html_e( sprintf( _n( 'Successfully migrated %d Sitewide Sales from the Sitewide Sales Add On for Paid Memberships Pro.', 'Successfully migrated %d Sitewide Sales from the Sitewide Sales Add On for Paid Memberships Pro.', intval($_REQUEST['swsales_pmpro_migrated_sales']), 'sitewide-sales' ), $_REQUEST['swsales_pmpro_migrated_sales'] ) ); ?></p>
+				</div>
+			<?php
+		}
+
 		// Was this notice already dismissed?
 		$sws_migration_notice_dismissed = get_option( 'sws_pmpro_migration_notice_dismissed', 0 );
 		if ( $sws_migration_notice_dismissed ) {
@@ -391,7 +399,12 @@ class SWSales_Module_PMPro {
 			" );
 
 		}
-		wp_redirect( admin_url( '/edit.php?post_type=sitewide_sale' ) );
+		// After all CPTs are converted, clean up and deactivate PMProSWS.
+		delete_option( 'pmpro_sitewide_sales' );
+		deactivate_plugins( '/pmpro-sitewide-sales/pmpro-sitewide-sales.php' );
+		deactivate_plugins( '/pmpro-sitewide-sales-master/pmpro-sitewide-sales.php' );
+		deactivate_plugins( '/pmpro-sitewide-sales-dev/pmpro-sitewide-sales.php' );
+		wp_redirect( admin_url( '/edit.php?post_type=sitewide_sale&swsales_pmpro_migrated_sales=' . count( $pmpro_sws_sale_ids ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Added dismissible banner to all SWSales pages (besides while editing a sitewide sale) to allow users to migrate old pmpro_sitewide_sales CPTs to sitewide_sales CPTs.

Migration process should be safe even if it times out.

We still need to add a permanent link for this on the About page.