### PR TITLE
Remove old swsales_callback functionality

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -16,9 +16,7 @@ class SWSales_MetaBoxes {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 		add_action( 'load-post.php', array( __CLASS__, 'init_metabox' ) );
 		add_action( 'load-post-new.php', array( __CLASS__, 'init_metabox' ) );
-		add_action( 'save_post', array( __CLASS__, 'landing_page_on_save' ), 10, 3 );
 		add_action( 'enter_title_here', array( __CLASS__, 'update_title_placeholder_text' ), 10, 2 );
-		add_filter( 'redirect_post_location', array( __CLASS__, 'redirect_after_page_save' ), 10, 2 );
 		add_action( 'wp_ajax_swsales_create_landing_page', array( __CLASS__, 'create_landing_page_ajax' ) );
 	}
 
@@ -438,7 +436,7 @@ class SWSales_MetaBoxes {
 								?>
  style="display: none;"<?php } ?>>
 							<?php
-								$edit_page_url = admin_url( 'post.php?post=' . $current_page . '&action=edit&swsales_callback=' . $post->ID );
+								$edit_page_url = admin_url( 'post.php?post=' . $current_page . '&action=edit' );
 								$view_page_url = get_permalink( $current_page );
 							?>
 							<a target="_blank" class="button button-secondary" id="swsales_edit_landing_page" href="<?php echo esc_url( $edit_page_url ); ?>"><?php esc_html_e( 'edit page', 'sitewide-sales' ); ?></a>
@@ -836,37 +834,6 @@ class SWSales_MetaBoxes {
 			wp_redirect( esc_url_raw( admin_url( 'admin.php?page=pmpro-reports&report=swsales_reports' ) ) );
 			exit();
 		}
-	}
-
-	/**
-	 * Updates Sitewide Sale's landing page id on save
-	 *
-	 * @param int $saveid landing page being saved.
-	 */
-	public static function landing_page_on_save( $saveid ) {
-		if ( isset( $_REQUEST['swsales_callback'] ) ) {
-			update_post_meta( intval( $_REQUEST['swsales_callback'] ), 'swsales_landing_page_post_id', $saveid );
-		}
-	}
-
-	/**
-	 * Redirects to Sitewide Sale after landing page is saved
-	 *
-	 * @param  string $location Previous redirect location.
-	 * @param  int    $post_id  id of page that was edited.
-	 * @return string           New redirect location
-	 */
-	public static function redirect_after_page_save( $location, $post_id ) {
-		$post_type = get_post_type( $post_id );
-		// Grab referrer url to see if it was sent there from editing a sitewide sale.
-		$url = $_REQUEST['_wp_http_referer'];
-		if ( 'page' === $post_type && ! empty( strpos( $url, 'swsales_callback=' ) ) ) {
-			// Get id of sitewide sale to redirect to.
-			$sitewide_sale_id = explode( 'swsales_callback=', $url )[1];
-			$sitewide_sale_id = explode( '$', $sitewide_sale_id )[0];
-			$location         = esc_url_raw( admin_url( 'post.php?post=' . $sitewide_sale_id . '&action=edit' ) );
-		}
-		return $location;
 	}
 
 	/**

--- a/modules/class-swsales-module-pmpro.php
+++ b/modules/class-swsales-module-pmpro.php
@@ -38,9 +38,7 @@ class SWSales_Module_PMPro {
 		// Enqueue JS for Edit Sitewide Sale page.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 
-		// SWSale compatibility when editing/saving a discount code.
-		//add_action( 'admin_notices', array( __CLASS__, 'return_from_editing_discount_code_box' ) );
-		//add_action( 'pmpro_save_discount_code', array( __CLASS__, 'discount_code_on_save' ) );
+		// AJAX to create a discount code.
 		add_action( 'wp_ajax_swsales_pmpro_create_discount_code', array( __CLASS__, 'create_discount_code_ajax' ) );
 
 		// For the swsales_coupon helper function
@@ -489,23 +487,6 @@ class SWSales_Module_PMPro {
 	} // end admin_enqueue_scripts()
 
 	/**
-	 * COMMENTED OUT
-	 * Updates Sitewide Sale's discount code id on save
-	 *
-	 * @param int $saveid discount code being saved.
-	 */
-	public static function discount_code_on_save( $saveid ) {
-		if ( isset( $_REQUEST['swsales_pmpro_callback'] ) ) {
-			update_post_meta( intval( $_REQUEST['swsales_pmpro_callback'] ), 'swsales_pmpro_discount_code_id', $saveid );
-			?>
-			<script type="text/javascript">
-				window.location = "<?php echo esc_url( admin_url( 'post.php?post=' . intval( $_REQUEST['swsales_pmpro_callback'] ) . '&action=edit' ) ); ?>";
-			</script>
-			<?php
-		}
-	} // end discount_code_on_save()
-
-	/**
 	 * Get the coupon for a sitewide sale.
 	 * Callback for the swsales_coupon filter.
 	 */
@@ -519,25 +500,6 @@ class SWSales_Module_PMPro {
 		}
 		return $coupon;
 	}
-
-	/**
-	 * COMMENTED OUT
-	 * Displays a link back to Sitewide Sale when discount code is edited/saved
-	 */
-	public static function return_from_editing_discount_code_box() {
-		if ( isset( $_REQUEST['swsales_pmpro_callback'] ) && 'memberships_page_pmpro-discountcodes' === get_current_screen()->base ) {
-			?>
-			<div class="notice notice-success">
-				<p><?php esc_html_e( 'Click ', 'sitewide-sales' ); ?>
-					<a href="<?php echo esc_url( admin_url( 'post.php?post=' . intval( $_REQUEST['swsales_pmpro_callback'] ) . '&action=edit' ) ); ?>">
-						<?php esc_html_e( 'here', 'sitewide-sales' ); ?>
-					</a>
-					<?php esc_html_e( ' to go back to editing Sitewide Sale', 'sitewide-sales' ); ?>
-				</p>
-			</div>
-			<?php
-		}
-	} // end return_from_editing_discount_code_box()
 
 	/**
 	 * AJAX callback to create a new discount code for your sale


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Remove functionality that tried to redirect users back to editing a Sitewide Sale after editing an associated landing page or discount code. As the "Edit" button opens the landing page or discount code editing pages in new tabs, this behavior is not necessary.

This functionality was already commented out in the PMPro module.

Resolves #12 