### PR TITLE
Readme, EDD added in a few spots, Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # [Sitewide Sales](https://sitewidesales.com) #
 
 ### Welcome to the Sitewide Sales GitHub Repository
-Sitewide Sales allows you to run Black Friday, Cyber Monday, or other flash sales on your WordPress-powered eCommerce or membership site. The plugin offers modules for [WooCommerce](https://woocommerce.com) and [Paid Memberships Pro](https://www.paidmembershipspro.com).
+Sitewide Sales allows you to run Black Friday, Cyber Monday, or other flash sales on your WordPress-powered eCommerce or membership site. The plugin offers modules for [WooCommerce](https://woocommerce.com), [Paid Memberships Pro](https://www.paidmembershipspro.com), [Easy Digital Downloads](https://easydigitaldownloads.com/).
 
 Let Sitewide Sales handle your sale banners, notification bars, landing pages, and reporting. Running a sale like this used to require three or more separate plugins. Now you can run your sale with a single tool. At the same time, the Sitewide Sales plugin is flexible enough that you can use specific banner and landing page plugins if wanted.
 

--- a/classes/class-swsales-about.php
+++ b/classes/class-swsales-about.php
@@ -31,7 +31,7 @@ class SWSales_About {
 				<div class="sitewide_sales_meta">
 					<span class="sitewide_sales_version">v<?php echo SWSALES_VERSION; ?></span>
 					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=documentation" target="_blank" title="<?php esc_attr_e( 'Documentation', 'sitewide-sales' ); ?>"><?php esc_html_e( 'Documentation', 'sitewide-sales' ); ?></a>
-					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
+					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
 					<?php if ( swsales_license_is_valid() ) { ?>
 						<?php printf(__( '<a class="swsales_license_tag swsales_license_tag-valid" href="%s">Valid License</a>', 'sitewide-sales' ), admin_url( 'edit.php?post_type=sitewide_sale&page=sitewide_sales_license' ) ); ?>
 					<?php } elseif ( ! defined( 'SWSALES_LICENSE_NAG' ) || SWSALES_LICENSE_NAG == true ) { ?>
@@ -88,7 +88,7 @@ class SWSales_About {
 						echo '<p>' . wp_kses( __( 'Check out the Sitewide Sales documentation site for additional setup instructions, sample landing page and banner content, as well as developer documentation to further extend the templates, reporting, and integration options.', 'sitewide-sales' ), $allowed_html ) . '</p>';
 					?>
 
-					<p><a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/?utm_source=plugin&utm_medium=swsales-about&utm_campaign=documentation" target="_blank" title="<?php esc_attr_e( 'Documentation', 'sitewide-sales' ); ?>"><?php esc_html_e( 'Documentation', 'sitewide-sales' ); ?></a> | <a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/support/?utm_source=plugin&utm_medium=swsales-about&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'View Support Options &raquo;', 'sitewide-sales' ); ?>"><?php esc_html_e( 'View Support Options &raquo;', 'sitewide-sales' ); ?></a></p>
+					<p><a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/?utm_source=plugin&utm_medium=swsales-about&utm_campaign=documentation" target="_blank" title="<?php esc_attr_e( 'Documentation', 'sitewide-sales' ); ?>"><?php esc_html_e( 'Documentation', 'sitewide-sales' ); ?></a> | <a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/support/?utm_source=plugin&utm_medium=swsales-about&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'View Support Options &raquo;', 'sitewide-sales' ); ?>"><?php esc_html_e( 'View Support Options &raquo;', 'sitewide-sales' ); ?></a></p>
 					
 					<?php do_action( 'swsales_about_text_bottom' ); ?>
 

--- a/classes/class-swsales-license.php
+++ b/classes/class-swsales-license.php
@@ -40,7 +40,7 @@ class SWSales_License{
 				<div class="sitewide_sales_meta">
 					<span class="sitewide_sales_version">v<?php echo SWSALES_VERSION; ?></span>
 					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=documentation" target="_blank" title="<?php esc_attr_e( 'Documentation', 'sitewide-sales' ); ?>"><?php esc_html_e( 'Documentation', 'sitewide-sales' ); ?></a>
-					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
+					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
 					<?php if ( swsales_license_is_valid() ) { ?>
 						<?php printf(__( '<a class="swsales_license_tag swsales_license_tag-valid" href="%s">Valid License</a>', 'sitewide-sales' ), admin_url( 'edit.php?post_type=sitewide_sale&page=sitewide_sales_license' ) ); ?>
 					<?php } elseif ( ! defined( 'SWSALES_LICENSE_NAG' ) || SWSALES_LICENSE_NAG == true ) { ?>

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -35,7 +35,7 @@ class SWSales_Reports {
 				<div class="sitewide_sales_meta">
 					<span class="sitewide_sales_version">v<?php echo SWSALES_VERSION; ?></span>
 					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=documentation" target="_blank" title="<?php esc_attr_e( 'Documentation', 'sitewide-sales' ); ?>"><?php esc_html_e( 'Documentation', 'sitewide-sales' ); ?></a>
-					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
+					<a href="https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/support/?utm_source=plugin&utm_medium=swsales-admin-header&utm_campaign=support" target="_blank" title="<?php esc_attr_e( 'Get Support', 'sitewide-sales' );?>"><?php esc_html_e( 'Get Support', 'sitewide-sales' );?></a>
 					<?php if ( swsales_license_is_valid() ) { ?>
 						<?php printf(__( '<a class="swsales_license_tag swsales_license_tag-valid" href="%s">Valid License</a>', 'sitewide-sales' ), admin_url( 'edit.php?post_type=sitewide_sale&page=sitewide_sales_license' ) ); ?>
 					<?php } elseif ( ! defined( 'SWSALES_LICENSE_NAG' ) || SWSALES_LICENSE_NAG == true ) { ?>

--- a/classes/class-swsales-setup.php
+++ b/classes/class-swsales-setup.php
@@ -137,7 +137,7 @@ class SWSales_Setup {
 		if ( strpos( $file, 'sitewide-sales.php' ) !== false ) {
 			$new_links = array(
 				'<a href="' . esc_url( 'https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/' ) . '" title="' . esc_attr( __( 'View Documentation', 'sitewide-sales' ) ) . '">' . __( 'Docs', 'sitewide-sales' ) . '</a>',
-				'<a href="' . esc_url( 'https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'sitewide-sales' ) ) . '">' . __( 'Support', 'sitewide-sales' ) . '</a>',
+				'<a href="' . esc_url( 'https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'sitewide-sales' ) ) . '">' . __( 'Support', 'sitewide-sales' ) . '</a>',
 			);
 			$links     = array_merge( $links, $new_links );
 		}

--- a/modules/class-swsales-module-edd.php
+++ b/modules/class-swsales-module-edd.php
@@ -98,7 +98,7 @@ class SWSales_Module_EDD {
 
 				$current_coupon = intval( $cur_sale->get_meta_value( 'swsales_edd_coupon_id', null ) );
 				?>
-					<th><label for="swsales_edd_coupon_id"><?php esc_html_e( 'Coupon', 'sitewide-sales' );?></label></th>
+					<th><label for="swsales_edd_coupon_id"><?php esc_html_e( 'Discount Code', 'sitewide-sales' );?></label></th>
 					<td>
 						<select class="coupon_select swsales_option" id="swsales_edd_coupon_select" name="swsales_edd_coupon_id">
 							<option value="0"><?php esc_html_e( '- Choose One -', 'sitewide-sales' ); ?></option>

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Sitewide Sales ===
 Contributors: strangerstudios, dlparker1005
 Tags: sales, sale, woocommerce, paid memberships pro, pmpro, black friday, cyber monday, discount
-Requires at least:
-Tested up to: 5.5.1
-Stable tag: 1.1
+Requires at least: 5.2
+Tested up to: 5.8.1
+Stable tag: 1.2
 
 Run Black Friday, Cyber Monday, or other flash sales on your WordPress-powered eCommerce or membership site.
 
@@ -13,7 +13,7 @@ The Sitewide Sales plugin allows you to create flash or sitewide sales. Use the 
 
 The plugin also adds the option to display sitewide page banners to advertise your sale and gives you statistics about the outcome of your sale.
 
-This plugin requires WooCommerce or Paid Memberships Pro to function. New integrations will be built as requested.
+This plugin offers modules for [WooCommerce](https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/sale-type/woocommerce/), [Paid Memberships Pro](https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/sale-type/paid-memberships-pro/), and [Easy Digital Downloads](https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/sale-type/easy-digital-downloads/). You can also use the [Custom sale module](https://www.strangerstudios.com/wordpress-plugins/sitewide-sales/documentation/sale-type/custom/) to track any banner > landing page > conversion workflow. New integrations will be built as requested.
 
 == Installation ==
 
@@ -22,6 +22,20 @@ This plugin requires WooCommerce or Paid Memberships Pro to function. New integr
 1. Create a new `Sitewide Sale` under `Sitewide Sales` > `Add New`.
 
 == Changelog ==
+
+= 1.2 - 2021-09-17 =
+* FEATURE: Added EDD module
+* FEATURE: Added "Custom" module
+* ENHANCEMENT: Start and end times can now be set for Sitewide Sales
+* ENHANCEMENT: Added daily revenue chart to reports
+* ENHANCEMENT: Clicking the discount code link in PMPro reports now shows the orders that have used that code
+* ENHANCEMENT: Added filter `swsales_pmpro_landing_page_default_discount_code`
+* BUG FIX/ENHANCEMENT: Now hiding discount code option for PMPro checkout on SWS landing page
+* BUG FIX: Now checking that PMPro discount code is valid before applying on landing page
+* BUG FIX: WooCommerce coupons are no longer being applied on every page
+* BUG FIX: Removed strike price from WC subscriptions as it wasn't showing consistently
+* BUG FIX: Resolved issue where `swsales_show_banner filter` would not always fire
+
 = 1.1 - 2020-09-21 =
 * NOTE: Sending launch emails today.
 * FEATURE: Added a one click migration from PMPro Sitewide Sales.

--- a/sitewide-sales.php
+++ b/sitewide-sales.php
@@ -5,7 +5,7 @@
  * Description: Run Black Friday, Cyber Monday, or other flash sales on your WordPress-powered eCommerce or membership site.
  * Author: Stranger Studios
  * Author URI: https://www.strangerstudios.com
- * Version: 1.1
+ * Version: 1.2
  * Plugin URI:
  * License: GNU GPLv2+
  * Text Domain: sitewide-sales
@@ -16,7 +16,7 @@ namespace Sitewide_Sales;
 
 defined( 'ABSPATH' ) || die( 'File cannot be accessed directly' );
 
-define( 'SWSALES_VERSION', '1.1' );
+define( 'SWSALES_VERSION', '1.2' );
 define( 'SWSALES_DIR', dirname( __FILE__ ) );
 define( 'SWSALES_BASENAME', plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
Updated the readme to add EDD in a few spots. 

Added changelog and incremented version; updated WP tested up to version.

Added links to module-specific documentation.

Fixed field labeled "Coupon" for the EDD Module (they call them Discount Codes and this was correct in other spots for the module).

Fixed broken links to the support information page on the Stranger Studios site.