### PR TITLE
Now checking that pages ar not empty before using is_page()

### DIFF
--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -255,8 +255,9 @@ class SWSales_Reports {
 
 		wp_register_script( 'swsales_tracking', plugins_url( 'js/swsales-tracking.js', SWSALES_BASENAME ), array( 'jquery', 'utils' ) );
 
+		$landing_page_post_id = $active_sitewide_sale->get_landing_page_post_id();
 		$swsales_data = array(
-			'landing_page'      => is_page( $active_sitewide_sale->get_landing_page_post_id() ),
+			'landing_page'      => ! empty( $landing_page_post_id ) && is_page( $landing_page_post_id ),
 			'sitewide_sale_id'  => $active_sitewide_sale->get_id(),
 			'ajax_url'          => admin_url( 'admin-ajax.php' ),
 		);

--- a/modules/class-swsales-module-edd.php
+++ b/modules/class-swsales-module-edd.php
@@ -255,7 +255,7 @@ class SWSales_Module_EDD {
 			return $is_checkout_page;
 		}
 		$edd_checkout_pages = array( edd_get_option( 'purchase_page' ), edd_get_option( 'success_page' ), edd_get_option( 'failure_page' ) );
-		return is_page( $edd_checkout_pages ) ? true : $is_checkout_page;
+		return ( ! empty( $edd_checkout_pages ) && is_page( $edd_checkout_pages ) ) ? true : $is_checkout_page;
 	}
 
 	/**
@@ -318,7 +318,7 @@ class SWSales_Module_EDD {
 
 		// Check if we are on the landing page
 		$landing_page_post_id             = intval( $active_sitewide_sale->get_landing_page_post_id() );
-		$on_landing_page                  = is_page( $landing_page_post_id );
+		$on_landing_page                  = ! empty( $landing_page_post_id ) && is_page( $landing_page_post_id );
 		$should_apply_discount_on_landing = ( 'none' !== $active_sitewide_sale->get_automatic_discount() );
 
 		// If discount code will be applied or we are on the landing page, strike prices.

--- a/modules/class-swsales-module-pmpro.php
+++ b/modules/class-swsales-module-pmpro.php
@@ -687,7 +687,7 @@ class SWSales_Module_PMPro {
 			return $is_checkout_page;
 		}
 		global $pmpro_pages;
-		return is_page( $pmpro_pages['checkout'] ) ? true : $is_checkout_page;
+		return ( ! empty( $pmpro_pages['checkout'] ) && is_page( $pmpro_pages['checkout'] ) ) ? true : $is_checkout_page;
 	}
 
 	/**

--- a/modules/class-swsales-module-wc.php
+++ b/modules/class-swsales-module-wc.php
@@ -249,7 +249,7 @@ class SWSales_Module_WC {
 		if ( 'wc' !== $sitewide_sale->get_sale_type() ) {
 			return $is_checkout_page;
 		}
-		return is_page( wc_get_page_id( 'cart' ) ) ? true : $is_checkout_page;
+		return ( ! empty( wc_get_page_id( 'cart' ) ) && is_page( wc_get_page_id( 'cart' ) ) ) ? true : $is_checkout_page;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issues when `is_page()` returns `true` after being passed empty inputs.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
