### PR TITLE
PMPro daily revenue chart now shows in local time

### DIFF
--- a/modules/class-swsales-module-pmpro.php
+++ b/modules/class-swsales-module-pmpro.php
@@ -848,7 +848,7 @@ class SWSales_Module_PMPro {
 		$query_data = $wpdb->get_results(
 			$wpdb->prepare(
 				"
-				SELECT DATE_FORMAT(o.timestamp, '%s') as date, SUM(o.total) as value
+				SELECT DATE_FORMAT( DATE_ADD( o.timestamp, INTERVAL %d HOUR ), '%s') as date, SUM(o.total) as value
 					FROM $wpdb->pmpro_membership_orders o
 				LEFT JOIN $wpdb->pmpro_discount_codes_uses dc
 					ON o.id = dc.order_id
@@ -859,6 +859,7 @@ class SWSales_Module_PMPro {
 				GROUP BY date
 				ORDER BY date
 				",
+				get_option( 'gmt_offset' ), // Convert to local time.
 				'%Y-%m-%d', // To prevent these from being seen as placeholders.
 				intval( $sitewide_sale->get_meta_value( 'swsales_pmpro_discount_code_id', null ) ),
 				get_gmt_from_date( $sitewide_sale->get_start_date( 'Y-m-d H:i:s' ) ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PMPro daily revenue chart now shows in local time

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
