### PR TITLE
EDD - Remove strikethrough on variable downloads

### DIFF
--- a/modules/class-swsales-module-edd.php
+++ b/modules/class-swsales-module-edd.php
@@ -316,6 +316,11 @@ class SWSales_Module_EDD {
 			return $price;
 		}
 
+		//If it's a variable price, don't strike through - we need to hook into edd_get_variable_prices
+		if( edd_has_variable_prices( $download_id ) ){
+			return $price;
+		}
+
 		// Check if we are on the landing page
 		$landing_page_post_id             = intval( $active_sitewide_sale->get_landing_page_post_id() );
 		$on_landing_page                  = ! empty( $landing_page_post_id ) && is_page( $landing_page_post_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By default we strike through the price on a product. This has caused issues where the text instead of the price is formatted on variable products. 

This PR will prevent the strikethrough on variable pricing until we can figure out a better way to handle this. 

### How to test the changes in this Pull Request:

1. Create a variable download
2. Set up your SWS sale to provide a discount
3. View the download.
4. It would normally strike out the price (standard downloads) but this has been removed on variable products

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

We no longer strike through variable download pricing
