### PR TITLE
Now using the input type date and time to set start and end dates/times on sales; input field width formatting

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -231,49 +231,17 @@ class SWSales_MetaBoxes {
 				<tr>
 					<th scope="row" valign="top"><label for="swsales_start_date"><?php esc_html_e( 'Sale Start Date', 'sitewide-sales' ); ?></label></th>
 					<td>
-						<select id="swsales_start_month" name="swsales_start_month">
-							<?php
-							for ( $i = 1; $i < 13; $i++ ) {
-								?>
-								<option value="<?php echo esc_attr( $i ); ?>" 
-														<?php
-														if ( $i == $cur_sale->get_start_date( 'm' ) ) {
-															?>
-									selected="selected"<?php } ?>><?php echo date_i18n( 'M', strtotime( $i . '/15/' . $cur_sale->get_start_year(), current_time( 'timestamp' ) ) ); ?></option>
-								<?php
-							}
-							?>
-						</select>
-						<input id="swsales_start_day" name="swsales_start_day" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_start_date( 'd' ) ); ?>" />
-						<input id="swsales_start_year" name="swsales_start_year" type="text" size="4" value="<?php echo esc_attr( $cur_sale->get_start_date( 'Y' ) ); ?>" />
-						<?php esc_html_e( 'at', 'sitewide-sales' ); ?>
-						<input id="swsales_start_hour" name="swsales_start_hour" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_start_date( 'H' ) ); ?>"/> :
-						<input id="swsales_start_minute" name="swsales_start_minute" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_start_date( 'i' ) ); ?>"/>
-						<p class="description"><?php esc_html_e( 'Set this date to the first day of your sale.', 'sitewide-sales' ); ?></p>
+						<input id="swsales_start_day" name="swsales_start_day" type="date" lang="<?php echo esc_attr( get_locale() ); ?>" value="<?php echo esc_attr( $cur_sale->get_start_date( 'Y-m-d' ) ); ?>" />
+						<input id="swsales_start_time" name="swsales_start_time" type="time" lang="<?php echo esc_attr( get_locale() ); ?>" value="<?php echo esc_attr( $cur_sale->get_start_date( 'H:i' ) ); ?>" />
+						<p class="description"><?php esc_html_e( 'Set this date and time to when your sale should begin.', 'sitewide-sales' ); ?></p>
 					</td>
 				</tr>
 				<tr>
 					<th scope="row" valign="top"><label for="swsales_end_date"><?php esc_html_e( 'Sale End Date', 'sitewide-sales' ); ?></label></th>
 					<td>
-					<select id="swsales_end_month" name="swsales_end_month">
-						<?php
-						for ( $i = 1; $i < 13; $i++ ) {
-							?>
-							<option value="<?php echo esc_attr( $i ); ?>" 
-													<?php
-													if ( $i == $cur_sale->get_end_date( 'm' ) ) {
-														?>
-								selected="selected"<?php } ?>><?php echo date_i18n( 'M', strtotime( $i . '/15/' . $cur_sale->get_end_year(), current_time( 'timestamp' ) ) ); ?></option>
-							<?php
-						}
-						?>
-					</select>
-					<input id="swsales_end_day" name="swsales_end_day" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_end_date( 'd' ) ); ?>" />
-					<input id="swsales_end_year" name="swsales_end_year" type="text" size="4" value="<?php echo esc_attr( $cur_sale->get_end_date( 'Y' ) ); ?>" />
-					<?php esc_html_e( 'at', 'sitewide-sales' ); ?>
-					<input id="swsales_end_hour" name="swsales_end_hour" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_end_date( 'H' ) ); ?>"/> :
-					<input id="swsales_end_minute" name="swsales_end_minute" type="text" size="2" value="<?php echo esc_attr( $cur_sale->get_end_date( 'i' ) ); ?>"/>
-					<p class="description"><?php esc_html_e( 'Set this date to the last full day of your sale.', 'sitewide-sales' ); ?></p>
+						<input id="swsales_end_day" name="swsales_end_day" type="date" lang="<?php echo esc_attr( get_locale() ); ?>" value="<?php echo esc_attr( $cur_sale->get_end_date( 'Y-m-d' ) ); ?>" />
+						<input id="swsales_end_time" name="swsales_end_time" type="time" lang="<?php echo esc_attr( get_locale() ); ?>" value="<?php echo esc_attr( $cur_sale->get_end_date( 'H:i' ) ); ?>" />
+						<p class="description"><?php esc_html_e( 'Set this date and time to when your sale should end.', 'sitewide-sales' ); ?></p>
 					</td>
 				</tr>
 					<th scope="row" valign="top"><label><?php esc_html_e( 'Sale Status', 'sitewide-sales' ); ?></label></th>
@@ -756,21 +724,15 @@ class SWSales_MetaBoxes {
 			update_post_meta( $post_id, 'swsales_landing_page_template', sanitize_text_field( $_POST['swsales_landing_page_template'] ) );
 		}
 
-		if ( isset( $_POST['swsales_start_day'] ) && is_numeric( $_POST['swsales_start_day'] ) &&
-				isset( $_POST['swsales_start_month'] ) && is_numeric( $_POST['swsales_start_month'] ) &&
-				isset( $_POST['swsales_start_year'] ) && is_numeric( $_POST['swsales_start_year'] ) &&
-				isset( $_POST['swsales_start_hour'] ) && is_numeric( $_POST['swsales_start_hour'] ) &&
-				isset( $_POST['swsales_start_minute'] ) && is_numeric( $_POST['swsales_start_minute'] ) &&
-				isset( $_POST['swsales_end_day'] ) && is_numeric( $_POST['swsales_end_day'] ) &&
-				isset( $_POST['swsales_end_month'] ) && is_numeric( $_POST['swsales_end_month'] ) &&
-				isset( $_POST['swsales_end_year'] ) && is_numeric( $_POST['swsales_end_year'] ) &&
-				isset( $_POST['swsales_end_hour'] ) && is_numeric( $_POST['swsales_end_hour'] ) &&
-				isset( $_POST['swsales_end_minute'] ) && is_numeric( $_POST['swsales_end_minute'] )
+		if ( isset( $_POST['swsales_start_day'] ) &&
+				isset( $_POST['swsales_start_time'] ) &&
+				isset( $_POST['swsales_end_day'] ) &&
+				isset( $_POST['swsales_end_time'] )
 		) {
-			$start_date = $_POST['swsales_start_year'] . '-' . $_POST['swsales_start_month'] . '-' . $_POST['swsales_start_day'] . ' ' . $_POST['swsales_start_hour'] . ':' . $_POST['swsales_start_minute'] . ':00' ;
+			$start_date = $_POST['swsales_start_day'] . ' ' . $_POST['swsales_start_time'] . ':00' ;
 			update_post_meta( $post_id, 'swsales_start_date', $start_date );
-			$start_date = $_POST['swsales_end_year'] . '-' . $_POST['swsales_end_month'] . '-' . $_POST['swsales_end_day'] . ' ' . $_POST['swsales_end_hour'] . ':' . $_POST['swsales_end_minute'] . ':00' ;
-			update_post_meta( $post_id, 'swsales_end_date', $start_date );
+			$end_date = $_POST['swsales_end_day'] . ' ' . $_POST['swsales_end_time'] . ':00' ;
+			update_post_meta( $post_id, 'swsales_end_date', $end_date );
 		}
 
 		if ( isset( $_POST['swsales_pre_sale_content'] ) ) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -102,6 +102,9 @@
 	display: block;
 	height: 100px;
 }
+.post-type-sitewide_sale input[type=text] {
+	width: 88%;
+}
 .post-type-sitewide_sale textarea {
 	line-height: 1.4;
 	resize: vertical;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The HTML input types "date" and "time" are now widely supported across browsers and should be a better user interface for setting sale start and end dates / times.

This PR swaps to using the single input types and updates how the meta is saved to string the date input and time input into one stored meta value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Now using date and time HTML input types for sale start and end date/time settings.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
