### PR TITLE
Reusable block banner; Accessible dismiss buttons; wording updates; showing banner even if landing page isn't set

### DIFF
--- a/classes/class-swsales-banner-module.php
+++ b/classes/class-swsales-banner-module.php
@@ -119,7 +119,7 @@ abstract class SWSales_Banner_Module {
 	
 		// Check if there is a landing page set for this sale and that we are not on the landing page.
 		$landing_page_post_id = $sitewide_sale->get_landing_page_post_id();
-		if ( empty( $landing_page_post_id ) || $landing_page_post_id < 0 || is_page( $landing_page_post_id ) ) {
+		if ( $landing_page_post_id < 0 || is_page( $landing_page_post_id ) ) {
 			return false;
 		}
 

--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -371,7 +371,7 @@ class SWSales_MetaBoxes {
 					<th><label for="swsales_landing_page_post_id"><?php esc_html_e( 'Landing Page', 'sitewide-sales' ); ?></label></th>
 					<td>
 						<select class="landing_page_select swsales_option" id="swsales_landing_page_select" name="swsales_landing_page_post_id">
-							<option value="0"><?php esc_html_e( '- Choose One -', 'sitewide-sales' ); ?></option>
+							<option value="0"><?php esc_html_e( '- No Landing Page -', 'sitewide-sales' ); ?></option>
 							<?php
 							$page_found = false;
 							foreach ( $pages as $page ) {
@@ -517,6 +517,7 @@ class SWSales_MetaBoxes {
 		}
 
 		$banner_modules        = apply_filters( 'swsales_banner_modules', array() );
+		ksort( $banner_modules );
 		$current_banner_module = $cur_sale->swsales_banner_module;
 
 		?>
@@ -526,7 +527,7 @@ class SWSales_MetaBoxes {
 					<th scope="row" valign="top"><label><?php esc_html_e( 'Banner Type', 'sitewide-sales' ); ?></label></th>
 					<td>
 						<select class="swsales_option" id="swsales_banner_module" name="swsales_banner_module">
-							<option value=""><?php esc_html_e( 'Do not use a banner', 'sitewide-sales' ); ?></option>
+							<option value=""><?php esc_html_e( '- No Banner -', 'sitewide-sales' ); ?></option>
 							<?php
 							foreach ( $banner_modules as $label => $module ) {
 								echo '<option value="' . esc_attr( $module ) . '"' . selected( $current_banner_module, $module ) . '>' . esc_html( $label ) . '</option>';

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -50,6 +50,18 @@
     color: #FFF;
 }
 
+/* Reusable Block Banner Styles */
+.swsales-banner-block a.swsales-dismiss:before {
+	background-color: rgba( 255, 255, 255, 0.7 );
+	border-radius: 50%;
+	color: #666;
+	display: table-cell;
+	font-size: 14px;
+	height: 20px;
+	text-align: center;
+	vertical-align: middle;
+	width: 20px;
+}
 /* Top Banner Styles */
 #swsales-banner-top {
 	padding: 15px;
@@ -67,7 +79,8 @@
 }
 
 /* Bottom Banner Styles */
-#swsales-banner-bottom {
+#swsales-banner-bottom,
+#swsales-banner-block-bottom {
 	bottom: 0;
 	box-shadow: 0 0 15px 0 rgba( 0, 0, 0, 0.6 );
 	left: 0;
@@ -76,7 +89,8 @@
 	width: 100%;
 	z-index: 400;
 }
-#swsales-banner-bottom a.swsales-dismiss {
+#swsales-banner-bottom a.swsales-dismiss,
+#swsales-banner-block-bottom a.swsales-dismiss {
 	position: absolute;
 	top: 10px;
 	right: 10px;
@@ -87,7 +101,8 @@
 	max-width: 1170px;
 	padding: 20px 25px 20px 15px;
 }
-#swsales-banner-bottom .swsales-banner-inner:after {
+#swsales-banner-bottom .swsales-banner-inner:after,
+#swsales-banner-block-bottom:after {
 	content: '';
 	clear: both;
 	display: block;
@@ -134,7 +149,16 @@
 	max-width: 300px;
 	z-index: 400;
 }
-#swsales-banner-bottom-right a.swsales-dismiss {
+#swsales-banner-block-bottom-right {
+	bottom: 0;
+	box-shadow: 0 0 15px 0 rgba( 0, 0, 0, 0.6 );
+	position: fixed;
+	right: 0;
+	max-width: 330px;
+	z-index: 400;
+}
+#swsales-banner-bottom-right a.swsales-dismiss,
+#swsales-banner-block-bottom-right a.swsales-dismiss {
 	position: absolute;
 	top: 10px;
 	right: 10px;

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -1,0 +1,303 @@
+<?php
+
+class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
+	/**
+	 * Set up the module.
+	 */
+	public static function init() {
+		parent::init();
+
+		// Set up showing banner on frontend.
+		add_action( 'wp', array( __CLASS__, 'choose_banner' ) );
+	}
+
+	/**
+	 * Logic for when to show banners/which banner to show
+	 */
+	public static function choose_banner() {
+		// are we previewing?
+		$preview = false;
+		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_sale_banner'] ) ) {
+			$active_sitewide_sale = Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_sitewide_sale( intval( $_REQUEST['swsales_preview_sale_banner'] ) );
+			$preview              = true;
+		} else {
+			$active_sitewide_sale = self::is_used_by_active_sitewide_sale();
+		}
+		// Return nothing if the sale isn't active.
+		if ( empty( $active_sitewide_sale ) ) {
+			return;
+		}
+
+		// Get the banner info and linked block.
+		$banner_info = self::get_banner_info( $active_sitewide_sale );
+		$banner_block = get_post( $banner_info['block_id'] );
+
+		// Unless we are previewing, don't show the banner on certain pages.
+		$show_banner = true;
+		if ( ! $preview ) {
+			$show_banner = self::banner_should_be_shown( $active_sitewide_sale );
+
+			// Don't show if the block is an error or not published.
+			if ( is_wp_error( $banner_block ) || get_post_status( $banner_block ) != 'publish' ) {
+				$show_banner = false;
+			}
+
+			// Don't show on login page.
+			if ( Sitewide_Sales\classes\SWSales_Setup::is_login_page() ) {
+				$show_banner = false;
+			}
+		}
+
+		// Return nothing if we shouldn't show the banner.
+		if ( empty( $show_banner ) ) {
+			return;
+		}
+		
+		// Display the appropriate banner
+		$registered_banners = self::get_registered_banners();
+
+		if ( array_key_exists( $banner_info['location'], $registered_banners ) && array_key_exists( 'callback', $registered_banners[ $banner_info['location'] ] ) ) {
+			$callback_func = $registered_banners[ $banner_info['location'] ]['callback'];
+			if ( is_array( $callback_func ) ) {
+				if ( 2 >= count( $callback_func ) ) {
+					call_user_func( $callback_func[0] . '::' . $callback_func[1] );
+				}
+			} elseif ( is_string( $callback_func ) ) {
+				if ( is_callable( $callback_func ) ) {
+					call_user_func( $callback_func );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Handles the process of showing a banner.
+	 */
+	public static function __callStatic( $name, $arguments ) {
+		switch ( $name ) {
+			case 'hook_top_banner':
+				add_action( 'wp_head', array( __CLASS__, 'show_top_banner' ) );
+				break;
+			case 'hook_bottom_banner':
+				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_banner' ) );
+				break;
+			case 'hook_bottom_right_banner':
+				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_right_banner' ) );
+				break;
+			case 'show_top_banner':
+			case 'show_bottom_banner':
+			case 'show_bottom_right_banner':
+				if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_sale_banner'] ) ) {
+					$active_sitewide_sale = Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_sitewide_sale( intval( $_REQUEST['swsales_preview_sale_banner'] ) );
+				} else {
+					$active_sitewide_sale = Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_active_sitewide_sale();
+				}
+				// Get the banner info.
+				$banner_info = self::get_banner_info( $active_sitewide_sale );
+
+				// Get the banner content.
+				$banner_block = get_post( $banner_info['block_id'] );
+				$banner_content = do_blocks( $banner_block->post_content );
+
+				ob_start();
+				?>
+				<div id="swsales-banner-block-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner swsales-banner-block">
+					<?php
+						switch ( $name ) {
+							case 'show_top_banner':
+								echo $banner_content;
+								break;
+							case 'show_bottom_banner':
+								?>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-bottom').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
+								<?php echo $banner_content; ?>
+								<?php
+								break;
+							case 'show_bottom_right_banner':
+								?>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
+								<?php echo $banner_content; ?>								
+								<?php
+								break;
+						}
+					?>
+				</div> <!-- end swsales-banner -->
+				<?php
+
+				$content = ob_get_contents();
+				ob_end_clean();
+
+				// Filter for themes and plugins to modify the banner content.
+				$content = apply_filters( 'swsales_banner_content', $content, $banner_info['template'], 'top' );
+
+				// Echo the banner content.	
+				echo $content;
+				break;
+			default:
+				// Throw exception if method not supported.
+				throw new Exception('The ' . $name . ' method is not supported.');
+		}
+	}
+
+	/**
+	 * Returns a human-readable name for this module.
+	 *
+	 * @return string
+	 */
+	protected static function get_module_label() {
+		return __( 'Reusable Block', 'sitewide-sales' );
+	}
+
+	/**
+	 * Returns whether the plugin associaited with this module is active.
+	 *
+	 * @return bool
+	 */
+	protected static function is_module_active() {
+		return true;
+	}
+
+	/**
+	 * Echos the HTML for the settings that should be displayed
+	 * if this module is active and selected while editing a
+	 * sitewide sale.
+	 *
+	 * @param SWSales_Sitewide_Sale $sitewide_sale The sale being edited.
+	 */
+	protected static function echo_banner_settings_html_inner( $sitewide_sale ) {
+		// Gather information information needed to display settings.
+		$banner_info          = self::get_banner_info( $sitewide_sale );
+		$registered_locations = self::get_registered_banners();
+
+		// Query to get all reusable blocks for dropdown.
+		$args = array(
+			'order' => 'ASC',
+			'orderby' => 'title',
+			'posts_per_page' => -1,
+			'post_status' => array( 'draft', 'publish' ),
+			'post_type' => 'wp_block'
+		);
+		$all_reusable_blocks = new WP_Query( $args );
+		?>
+		<tr>
+			<th scope="row" valign="top"><label><?php esc_html_e( 'Reusable Block', 'sitewide-sales' ); ?></label></th>
+			<td>
+				<?php
+					$block_found = false;
+					if ( $all_reusable_blocks->have_posts() ) { ?>
+						<select class="swsales_option" id="swsales_banner_block_id" name="swsales_banner_block_id">
+							<option value="0"><?php esc_html_e( '- Choose One -', 'sitewide-sales' ); ?></option>
+							<?php
+								while ( $all_reusable_blocks->have_posts() ) {
+									$all_reusable_blocks->the_post();
+									if ( selected( $banner_info['block_id'], $all_reusable_blocks->post->ID, false ) ) {
+										$block_found = true;
+									}
+									if ( $all_reusable_blocks->post->post_status == 'draft' ) {
+										$status_part = ' (' . esc_html__( 'Draft', 'sitewide-sales' ) . ')';
+									} else {
+										$status_part = '';
+									}
+									echo '<option value="' . esc_attr( $all_reusable_blocks->post->ID ) . '"' . selected( $banner_info['block_id'], $all_reusable_blocks->post->ID ) . '>' . esc_html( $all_reusable_blocks->post->post_title ) . $status_part . '</option>';
+								}
+							?>
+						</select>
+					<?php
+						wp_reset_postdata();
+						} else { ?>
+							<p><?php _e( 'Sorry, no posts matched your criteria.' ); ?></p>
+						<?php
+						}
+					?>
+				<p>
+					<span id="swsales_after_reusable_block_select" 
+					<?php
+					if ( ! $block_found ) {
+						?>
+style="display: none;"<?php } ?>>
+					<?php
+						$edit_block_url = admin_url( 'post.php?post=' . $banner_info['block_id'] . '&action=edit' );
+					?>
+					<a target="_blank" class="button button-secondary" id="swsales_edit_banner_block" href="<?php echo esc_url( $edit_block_url ); ?>"><?php esc_html_e( 'edit block', 'sitewide-sales' ); ?></a>
+					<?php
+						esc_html_e( ' or ', 'sitewide-sales' );
+					?>
+					</span>
+					<button type="button" id="swsales_create_banner_block" class="button button-secondary"><?php esc_html_e( 'create a new reusable block', 'sitewide-sales' ); ?></button>
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row" valign="top"><label><?php esc_html_e( 'Banner Location', 'sitewide-sales' ); ?></label></th>
+			<td>
+				<select class="swsales_option" name="swsales_banner_block_location">
+					<?php
+					foreach ( $registered_locations as $registered_location_slug => $registered_location_data ) {
+						if ( is_string( $registered_location_slug ) && is_array( $registered_location_data ) && ! empty( $registered_location_data['option_title'] ) && is_string( $registered_location_data['option_title'] ) ) {
+							echo '<option value="' . esc_attr( $registered_location_slug ) . '"' . selected( $banner_info['location'], $registered_location_slug ) . '>' . esc_html( $registered_location_data['option_title'] ) . '</option>';
+						}
+					}
+					?>
+				</select>
+			</td>
+		</tr>
+		<?php
+    }
+
+	/**
+	 * Saves settings shown by echo_banner_settings_html_inner().
+	 *
+	 * @param int     $post_id The ID of the post being saved.
+	 * @param WP_Post $post The post being saved.
+	 */
+	protected static function save_banner_settings( $post_id, $post ) {
+		if ( isset( $_POST['swsales_banner_block_location'] ) ) {
+			update_post_meta( $post_id, 'swsales_banner_block_location', sanitize_text_field( $_POST['swsales_banner_block_location'] ) );
+		}
+		if ( isset( $_POST['swsales_banner_block_id'] ) ) {
+			update_post_meta( $post_id, 'swsales_banner_block_id', sanitize_text_field( $_POST['swsales_banner_block_id'] ) );
+		}
+    }
+
+    /**
+	 * Get banner info for the given sitewide sale.
+	 *
+	 * @param SWSales_Sitewide_Sale $sitewide_sale The sitewide sale to get the banner info for.
+	 * @return array The banner info.
+	 */
+	private static function get_banner_info( $sitewide_sale ) {
+		$banner_info = array();
+		$banner_info['block_id'] = $sitewide_sale->get_meta_value( 'swsales_banner_block_id' );
+		$banner_info['location'] = $sitewide_sale->get_meta_value( 'swsales_banner_block_location' );
+		// Update location in case we are previewing.
+		if ( ! is_admin() && current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_sale_banner_type'] ) ) {
+			$banner_info['location'] = $_REQUEST['swsales_preview_sale_banner_type'];
+		}
+		return $banner_info;
+	}
+
+	/**
+	 * Gets info about available banners including name and available
+	 * css selectors.
+	 *
+	 * @return array banner_name => array( option_title=>string, callback=>string )
+	 */
+	private static function get_registered_banners() {
+		$registered_banners = array(
+			'top'          => array(
+				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
+				'callback'      => array( __CLASS__, 'hook_top_banner' ),
+			),
+			'bottom'       => array(
+				'option_title'  => __( 'Bottom of Site', 'sitewide-sales' ),
+				'callback'      => array( __CLASS__, 'hook_bottom_banner' ),
+			),
+			'bottom_right' => array(
+				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
+				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
+			),
+		);
+		return $registered_banners;
+	}
+}
+SWSales_Banner_Module_Blocks::init();

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -149,7 +149,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								break;
 							case 'show_bottom_banner':
 								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom').style.display = 'none';" class="swsales-dismiss" title="Dismiss"></a>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<div class="swsales-banner-inner-left">
 									<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 									<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'bottom', $active_sitewide_sale ); ?></p>
@@ -162,7 +162,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								break;
 							case 'show_bottom_right_banner':
 								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"></a>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'bottom_right', $active_sitewide_sale ); ?></p>
 								<?php
@@ -199,7 +199,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	 * @return string
 	 */
 	protected static function get_module_label() {
-		return __( 'Built-In Banners', 'sitewide-sales' );
+		return __( 'Custom Banner', 'sitewide-sales' );
 	}
 
 	/**
@@ -274,7 +274,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 			<th scope="row" valign="top"><label><?php esc_html_e( 'Button Text', 'sitewide-sales' ); ?></label></th>
 			<td>
 				<input class="swsales_option" type="text" name="swsales_banner_button_text" value="<?php echo esc_attr( $banner_info['button_text'] ); ?>">
-				<p class="description"><?php esc_html_e( 'The text displayed on the button of your banner that links to the Landing Page.', 'sitewide-sales' ); ?></p>
+				<p class="description"><?php esc_html_e( 'The text displayed on the button of your banner that links to the Landing Page. If you do not set a landing page, no button will be shown.', 'sitewide-sales' ); ?></p>
 			</td>
 		</tr>
 		<tr>
@@ -397,7 +397,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 
 		$registered_banners = array(
 			'top'          => array(
-				'option_title'  => __( 'Yes, Top of Site', 'sitewide_Sales' ),
+				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
 				'callback'      => array( __CLASS__, 'hook_top_banner' ),
 				'css_selectors' => array(
 					'#swsales-banner-top',
@@ -408,7 +408,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 				),
 			),
 			'bottom'       => array(
-				'option_title'  => __( 'Yes, Bottom of Site', 'sitewide-sales' ),
+				'option_title'  => __( 'Bottom of Site', 'sitewide-sales' ),
 				'callback'      => array( __CLASS__, 'hook_bottom_banner' ),
 				'css_selectors' => array(
 					'#swsales-banner-bottom',
@@ -423,7 +423,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 				),
 			),
 			'bottom_right' => array(
-				'option_title'  => __( 'Yes, Bottom Right of Site', 'sitewide-sales' ),
+				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
 				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
 				'css_selectors' => array(
 					'#swsales-banner-bottom-right',

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -132,7 +132,13 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 					$active_sitewide_sale = Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_active_sitewide_sale();
 				}
 				$banner_info = self::get_banner_info( $active_sitewide_sale );
-		
+
+				// Get the landing page URL.
+				$landing_page_id = $active_sitewide_sale->get_landing_page_post_id();
+				if ( ! empty( $landing_page_id ) ) {
+					$landing_page_url = get_permalink( $landing_page_id );
+				}
+
 				ob_start();
 				?>
 				<div id="swsales-banner-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner">
@@ -144,7 +150,12 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'top', $active_sitewide_sale ); ?></p>
 								<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>
-								<span class="swsales-banner-button-wrap"><a class="swsales-banner-button" href="<?php echo esc_url( get_permalink( $active_sitewide_sale->get_landing_page_post_id() ) ); ?>"><?php echo wp_kses_post( $banner_info['button_text'] ); ?></a></span>
+								<?php
+									if ( ! empty( $landing_page_url ) && ! is_wp_error( $landing_page_url ) ) { ?>
+										<span class="swsales-banner-button-wrap"><a class="swsales-banner-button" href="<?php echo esc_url( $landing_page_url ); ?>"><?php echo wp_kses_post( $banner_info['button_text'] ); ?></a></span>
+										<?php
+									}
+								?>
 								<?php
 								break;
 							case 'show_bottom_banner':
@@ -156,7 +167,12 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								</div>
 								<div class="swsales-banner-inner-right">
 									<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>
-									<span class="swsales-banner-button-wrap"><a class="swsales-banner-button" href="<?php echo esc_url( get_permalink( $active_sitewide_sale->get_landing_page_post_id() ) ); ?>"><?php echo wp_kses_post( $banner_info['button_text'] ); ?></a></span>
+									<?php
+										if ( ! empty( $landing_page_url ) ) { ?>
+											<span class="swsales-banner-button-wrap"><a class="swsales-banner-button" href="<?php echo esc_url( $landing_page_url ); ?>"><?php echo wp_kses_post( $banner_info['button_text'] ); ?></a></span>
+											<?php
+										}
+									?>
 								</div>
 								<?php
 								break;
@@ -165,6 +181,13 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'bottom_right', $active_sitewide_sale ); ?></p>
+								<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>
+								<?php
+									if ( ! empty( $landing_page_url ) && ! is_wp_error( $landing_page_url ) ) { ?>
+										<span class="swsales-banner-button-wrap"><a class="swsales-banner-button" href="<?php echo esc_url( $landing_page_url ); ?>"><?php echo wp_kses_post( $banner_info['button_text'] ); ?></a></span>
+										<?php
+									}
+								?>
 								<?php
 								break;
 						}
@@ -178,11 +201,11 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 
 				// Filter for templates to modify the banner content.
 				if ( ! empty( $banner_info['template'] ) ) {
-					$content = apply_filters( 'swsales_banner_content_' . $banner_info['template'], $content, 'top' );
+					$content = apply_filters( 'swsales_banner_content_' . $banner_info['template'], $content, $banner_info['location'] );
 				}
 
 				// Filter for themes and plugins to modify the banner content.
-				$content = apply_filters( 'swsales_banner_content', $content, $banner_info['template'], 'top' );
+				$content = apply_filters( 'swsales_banner_content', $content, $banner_info['template'], $banner_info['location'] );
 
 				// Echo the banner content.	
 				echo $content;

--- a/sitewide-sales.php
+++ b/sitewide-sales.php
@@ -70,6 +70,7 @@ function swsales_load_modules() {
 	require_once SWSALES_DIR . '/modules/ecommerce/edd/class-swsales-module-edd.php';
 
 	require_once SWSALES_DIR . '/classes/class-swsales-banner-module.php';
+    require_once SWSALES_DIR . '/modules/banner/blocks/class-swsales-banner-module-blocks.php';
 	require_once SWSALES_DIR . '/modules/banner/swsales/class-swsales-banner-module-swsales.php';
 	require_once SWSALES_DIR . '/modules/banner/pum/class-swsales-banner-module-pum.php';
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Added option to design banners with reusable blocks. We need to still code up the "create a new reusable block" button.
- Updating some wording and changed name of built-in banner to "custom banner".
- now showing banners even if the landing page is not set. in the custom banner module, the button will only show if there is a landing page.
- CSS updates to support reusable blocks.
- Added "dismiss" text for screen readers and closing banners.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
