### PR TITLE
Reqworking the admin page a bit; adding a quick report view for CPT edit

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -73,6 +73,14 @@ class SWSales_MetaBoxes {
 			'high'
 		);
 		add_meta_box(
+			'swsales_cpt_reports',
+			__( 'Quick Reports', 'sitewide-sales' ),
+			array( __CLASS__, 'display_cpt_reports' ),
+			array( 'sitewide_sale' ),
+			'side',
+			'high'
+		);
+		add_meta_box(
 			'swsales_documentation',
 			__( 'Documentation', 'sitewide-sales' ),
 			array( __CLASS__, 'documentation' ),
@@ -112,14 +120,6 @@ class SWSales_MetaBoxes {
 			'normal',
 			'high'
 		);
-		add_meta_box(
-			'swsales_cpt_step_5',
-			__( 'Step 5: Reports', 'sitewide-sales' ),
-			array( __CLASS__, 'display_step_5' ),
-			array( 'sitewide_sale' ),
-			'normal',
-			'high'
-		);
 
 		// remove some default metaboxes
 		remove_meta_box( 'slugdiv', 'sitewide_sale', 'normal' );
@@ -147,15 +147,42 @@ class SWSales_MetaBoxes {
 			}
 		}
 		?>
+		<?php
+			$sale_status_running = $cur_sale->is_running();
+
+			if ( $sale_status_running === true ) {
+				echo '<div class="sitewide_sales_message sitewide_sales_success">';
+				echo '<strong>' . esc_html( 'Running.', 'sitewide-sales' ) . '</strong>';
+				echo ' ' .  esc_html( 'This is the active sitewide sale.', 'sitewide-sales' );
+			} else {
+				echo '<div class="sitewide_sales_message sitewide_sales_alert">';
+				echo '<strong>' . esc_html( 'Not Running.', 'sitewide-sales' ) . '</strong>';
+
+				if ( ! $cur_sale->is_active_sitewide_sale() ) {
+					$error_message = esc_html( 'This is not the active sitewide sale.', 'sitewide-sales' );
+				} else {
+					switch ( $cur_sale->get_time_period() ) {
+						case 'error':
+							$error_message = esc_html( 'Invalid timeframe.', 'sitewide-sales' );
+							break;
+						case 'pre-sale':
+							$error_message = esc_html( 'Sale has not yet started.', 'sitewide-sales' );
+							break;
+						case 'post-sale':
+							$error_message = esc_html( 'Sale has ended.', 'sitewide-sales' );
+							break;
+					}
+				}
+				echo ' ' . $error_message . ' ' . esc_html( 'Banner will not be shown.', 'sitewide-sales' );
+			}
+			echo '</div>';
+		?>
 		<div id="misc-publishing-actions">
 			<div class="misc-pub-section">
 				<p>
 					<label for="swsales_set_as_sitewide_sale"><strong><?php esc_html_e( 'Set as Current Sitewide Sale', 'sitewide-sales' ); ?></strong></label>
 					<input name="swsales_set_as_sitewide_sale" id="swsales_set_as_sitewide_sale" type="checkbox" <?php checked( $init_checked, true ); ?> />
 				</p>
-			</div>
-			<div class="misc-pub-section">
-				<p><a target="_blank" href="<?php echo esc_url( admin_url( 'edit.php?post_type=sitewide_sale&page=sitewide_sales_reports&sitewide_sale=' . $post->ID ) ); ?>"><?php esc_html_e( 'View Sitewide Sale Reports', 'sitewide-sales' ); ?></a></p>
 			</div>
 		</div>
 		<div id="major-publishing-actions">
@@ -243,40 +270,6 @@ class SWSales_MetaBoxes {
 						<input id="swsales_end_time" name="swsales_end_time" type="time" lang="<?php echo esc_attr( get_locale() ); ?>" value="<?php echo esc_attr( $cur_sale->get_end_date( 'H:i' ) ); ?>" />
 						<p class="description"><?php esc_html_e( 'Set this date and time to when your sale should end.', 'sitewide-sales' ); ?></p>
 					</td>
-				</tr>
-					<th scope="row" valign="top"><label><?php esc_html_e( 'Sale Status', 'sitewide-sales' ); ?></label></th>
-					<td>
-						<?php
-							$sale_status_running = $cur_sale->is_running();
-
-							if ( $sale_status_running === true ) {
-								echo '<p class="sitewide_sales_message sitewide_sales_success">';
-								echo '<strong>' . esc_html( 'Running.', 'sitewide-sales' ) . '</strong>';
-							} else {
-								echo '<div class="sitewide_sales_message sitewide_sales_alert">';
-								echo '<strong>' . esc_html( 'Not Running.', 'sitewide-sales' ) . '</strong>';
-
-								if ( ! $cur_sale->is_active_sitewide_sale() ) {
-									$error_message = 'This is not the active sitewide sale.';
-								} else {
-									switch ( $cur_sale->get_time_period() ) {
-										case 'error':
-											$error_message = esc_html( 'Invalid timeframe.', 'sitewide-sales' );
-											break;
-										case 'pre-sale':
-											$error_message = esc_html( 'Sale has not yet started.', 'sitewide-sales' );
-											break;
-										case 'post-sale':
-											$error_message = esc_html( 'Sale has ended.', 'sitewide-sales' );
-											break;
-									}
-								}
-								echo ' ' . $error_message . ' ' . esc_html( 'Banner will not be shown.', 'sitewide-sales' );
-							}
-							echo '</p>';
-						?>
-					</td>
-				<tr>
 				</tr>
 			</tbody>
 		</table>
@@ -398,11 +391,6 @@ class SWSales_MetaBoxes {
 							$show_shortcode_warning = true;
 						}
 						?>
-						<p class="sitewide_sales_message sitewide_sales_alert swsales_shortcode_warning"
-							<?php if ( ! $show_shortcode_warning ) { ?>style="display: none;"<?php } ?>>
-							<?php echo wp_kses_post( '<strong>Warning:</strong> The [sitewide_sales] shortcode was not found in this post.', 'sitewide-sales' ); ?>
-						</p>
-
 						<p>
 							<span id="swsales_after_landing_page_select" 
 							<?php
@@ -592,15 +580,17 @@ class SWSales_MetaBoxes {
 		<?php
 	}
 
-	public static function display_step_5( $post ) {
+	public static function display_cpt_reports( $post ) {
 		global $wpdb, $cur_sale;
 		if ( ! isset( $cur_sale ) ) {
 			$cur_sale = new SWSales_Sitewide_Sale();
 			$cur_sale->load_sitewide_sale( $post->ID );
 		}
-		SWSales_Reports::show_report( $cur_sale );
+		SWSales_Reports::show_quick_report( $cur_sale );
 		?>
-		<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'sitewide-sales' ); ?>">
+		<div class="swsales_reports-quick-data-action">
+			<a class="button button-secondary" target="_blank" href="<?php echo esc_url( admin_url( 'edit.php?post_type=sitewide_sale&page=sitewide_sales_reports&sitewide_sale=' . $post->ID ) ); ?>"><?php esc_html_e( 'View Detailed Sale Report', 'sitewide-sales' ); ?></a>
+		</div>
 		<?php
 	}
 

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -235,6 +235,35 @@ class SWSales_Reports {
 		do_action( 'swsales_additional_reports', $sitewide_sale );
 	}
 
+	/**
+	 * Show summarized report content for a Sitewide Sale.
+	 *
+	 * @param SWSales_Sitewide_Sale $sitewide_sale to show report for.
+	 */
+	public static function show_quick_report( $sitewide_sale ) {
+		if ( ! is_a( $sitewide_sale, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) ) {
+			return;
+		}
+		?>
+		<div class="swsales_reports-quick-data-section">
+			<span class="swsales_reports-quick-data-label"><?php esc_html_e( 'Banner Reach', 'sitewide-sales' ); ?></span>
+			<span class="swsales_reports-quick-data-value"><?php echo esc_attr( $sitewide_sale->get_banner_impressions() ); ?></span>
+		</div>
+		<div class="swsales_reports-quick-data-section">
+			<span class="swsales_reports-quick-data-label"><?php esc_html_e( 'Landing Page Visits', 'sitewide-sales' ); ?></span>
+			<span class="swsales_reports-quick-data-value"><?php echo esc_attr( $sitewide_sale->get_landing_page_visits() ); ?></span>
+		</div>
+		<div class="swsales_reports-quick-data-section">
+			<span class="swsales_reports-quick-data-label"><?php esc_html_e( 'Conversions', 'sitewide-sales' ); ?></span>
+			<span class="swsales_reports-quick-data-value"><?php echo esc_attr( $sitewide_sale->get_checkout_conversions() ); ?></span>
+		</div>
+		<div class="swsales_reports-quick-data-section">
+			<span class="swsales_reports-quick-data-label"><?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?></span>
+			<span class="swsales_reports-quick-data-value"><?php echo esc_attr( $sitewide_sale->get_revenue() ); ?></span>
+		</div>
+		<?php
+	}
+
 	public static function admin_enqueue_scripts() {
 		global $typenow;
 		$screen = get_current_screen();

--- a/css/admin.css
+++ b/css/admin.css
@@ -61,34 +61,39 @@
 .sitewide_sales_message,
 .form-table td p.sitewide_sales_message {
 	background-color: #f7fcfe;
-    border-left: 4px solid #00a0d2;
-    margin-bottom: 1em;
-    margin-right: 1.5em;
-    padding: 15px;
+	border-color: #00a0d2;
+	border-style: solid;
+	border-width: 0 0 0 4px;
+	color: #3c434a;
+	margin-bottom: 1em;
+	padding: 15px;
 }
 .sitewide_sales_message.sitewide_sales_success,
 .form-table td p.sitewide_sales_message.sitewide_sales_success {
-    border-left-color: #4ab866;
-    background-color: #eff9f1;
+    border-color: #c3e6cb;
+    background-color: #d4edda;
 }
 .sitewide_sales_message.sitewide_sales_error,
 .form-table td p.sitewide_sales_message.sitewide_sales_error {
-    border-left-color: #d94f4f;
-    background-color: #f9e2e2;
+    border-color: #f5c6cb;
+    background-color: #f8d7da;
 }
 .sitewide_sales_message.sitewide_sales_alert,
 .form-table td p.sitewide_sales_message.sitewide_sales_alert {
-    border-left-color: #f0b849;
-    background-color: #fef8ee;
+    border-color: #ffeeba;
+    background-color: #FFF8E0;
 }
 .sitewide_sales_message.sitewide_sales_success a {
-    color: #208A1B;
+    color: #0F441C;
 }
 .sitewide_sales_message.sitewide_sales_error a {
-    color: #CC0000;
+    color: #721c24;
 }
 .sitewide_sales_message.sitewide_sales_alert a {
-    color: #CF8516;
+    color: #6C5101;
+}
+.form-table td .sitewide_sales_message p {
+	margin: 0;
 }
 
 /* Sitewide Sales Custom Post Type */
@@ -114,13 +119,6 @@
 }
 .post-type-sitewide_sale .form-table tr th small a {
 	font-weight: normal;
-} 
-.post-type-sitewide_sale #swsales_cpt_publish_sitewide_sale .inside {
-	margin: 0;
-	padding: 0;
-}
-.post-type-sitewide_sale #swsales_cpt_publish_sitewide_sale .misc-pub-section {
-	padding: 0 12px;
 }
 .post-type-sitewide_sale .swsales_banner_css_selectors {
 	background: aliceblue;
@@ -128,13 +126,42 @@
 	width: 77%;
 }
 
+.post-type-sitewide_sale button.swsales-row-trigger-button {
+	align-items: center;
+	-webkit-appearance: none;
+	background: none;
+	border: none;
+	box-shadow: none;
+	box-sizing: border-box;
+	color: #2271b1;
+	cursor: pointer;
+	height: auto;
+	margin: 0;
+	outline: none;
+	padding: 0;
+	position: relative;
+	text-align: left;
+	text-decoration: underline;
+	width: 100%;
+}
+.post-type-sitewide_sale button.swsales-row-trigger-button:hover {
+	color: #135e96;
+}
+
+/* Admin Meta Box */
+.post-type-sitewide_sale #swsales_cpt_publish_sitewide_sale .inside {
+	margin: 0;
+	padding: 0;
+}
+.post-type-sitewide_sale #swsales_cpt_publish_sitewide_sale .misc-pub-section {
+	padding: 0 1em;
+}
+.post-type-sitewide_sale #swsales_cpt_publish_sitewide_sale .sitewide_sales_message {
+	border-width: 0 0 4px 0;
+	margin-bottom: 0;
+}
+
 /* Documentation Meta Box */
-#swsales_documentation.postbox {
-	background: #F5F5F5;
-}
-#swsales_documentation.postbox h2 {
-	border-bottom: 1px solid #DDD;
-}
 #swsales_documentation.postbox ul li {
 	margin-bottom: 15px;
 }
@@ -212,6 +239,30 @@
 	.swsales_reports-data-section h1:after {
 		content: ": ";
 	}
+}
+
+#swsales_cpt_reports .inside {
+	margin-top: 0;
+	padding: 0;
+}
+.swsales_reports-quick-data-section:nth-child(odd) {
+	background: #f6f7f7;
+}
+.swsales_reports-quick-data-section {
+	border-bottom: 1px solid #dcdcde;
+	display: grid;
+	grid-template-columns: 2fr auto;
+	padding: 1em;
+}
+.swsales_reports-quick-data-label {
+	font-weight: bold;
+}
+.swsales_reports-quick-data-value {
+	text-align: right;
+}
+.swsales_reports-quick-data-action {
+	padding: 1em;
+	text-align: center;
 }
 
 /* Sitewide Sales About Page */

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -300,7 +300,15 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 				<p class="description"><?php esc_html_e( 'The text displayed on the button of your banner that links to the Landing Page. If you do not set a landing page, no button will be shown.', 'sitewide-sales' ); ?></p>
 			</td>
 		</tr>
-		<tr>
+		<tr class="swsales-row-trigger">
+			<th></th>
+			<td>
+				<button class="swsales-row-trigger-button" type="button">
+					<?php esc_html_e( '+ Add custom banner CSS', 'sitewide-sales' ); ?>
+				</button>
+			</td>
+		</tr>
+		<tr style="display: none;">
 			<th scope="row" valign="top"><label><?php esc_html_e( 'Custom Banner CSS', 'sitewide-sales' ); ?></label></th>
 			<td>
 				<textarea class="swsales_option" name="swsales_banner_css"><?php echo esc_textarea( $banner_info['css'] ); ?></textarea>
@@ -325,6 +333,26 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 				<?php } ?>
 			</td>
 		</tr>
+		<script>
+			jQuery(document).ready(function() {
+				swsales_prep_click_events();
+			});
+
+			// Function to prep click events for admin settings.
+			function swsales_prep_click_events() {
+				jQuery( 'button.swsales-row-trigger-button' ).on( 'click', function(event){
+					// Toggle content within the settings sections boxes.
+					event.preventDefault();
+
+					let thebutton = jQuery(event.target).parents('.swsales-row-trigger').find('button.swsales-row-trigger-button');
+					let sectionshow = jQuery( thebutton ).parents('.swsales-row-trigger').next('tr');
+					let sectionhide = jQuery(event.target).parents('.swsales-row-trigger');
+
+					jQuery( sectionshow ).show();
+					jQuery( sectionhide ).hide();
+				});
+			}
+		</script>
 		<?php
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Removed the large report on single CPT edit and made a smaller widget view.
* Moved the "sale status" message to the sidebar admin metabox
* Added a toggle link to add banner CSS (now not showing it by default)
* Accessible colors for contextual messages
* Removed duplicate warning about the [sitewide_sales] shortcode missing.