### PR TITLE
Insert reusable block functionality; banner close behavior

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -545,6 +545,27 @@ class SWSales_MetaBoxes {
 		<table class="form-table" id="swsales_banner_options">
 			<tbody>
 				<tr>
+					<th scope="row" valign="top"><label><?php esc_html_e( 'Banner Close Behavior', 'sitewide-sales' ); ?></label></th>
+					<td>
+						<select class="swsales_option" id="swsales_banner_close_behavior" name="swsales_banner_close_behavior">
+							<option value="refresh" <?php selected( $cur_sale->get_meta_value('swsales_banner_close_behavior'), 'refresh' ); ?>><?php esc_html_e( 'Close Until Refresh', 'sitewide-sales' ); ?></option>
+							<option value="session" <?php selected( $cur_sale->get_meta_value('swsales_banner_close_behavior'), 'session' ); ?>><?php esc_html_e( 'Close Until New Session', 'sitewide-sales' ); ?></option>
+						</select>
+						<p class="description"><?php esc_html_e( 'Select when the banner will reappear if the user closes or dismisses the banner.', 'sitewide-sales' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top"><label><?php esc_html_e( 'Page Scroll Behavior', 'sitewide-sales' ); ?></label></th>
+					<td>
+						<select class="swsales_option" id="swsales_banner_scroll_behavior" name="swsales_banner_scroll_behavior">
+							<option value="none" <?php selected( $cur_sale->get_meta_value('swsales_banner_scroll_behavior'), 'none' ); ?>><?php esc_html_e( 'Default Banner Behavior', 'sitewide-sales' ); ?></option>
+							<option value="sticky" <?php selected( $cur_sale->get_meta_value('swsales_banner_scroll_behavior'), 'sticky' ); ?>><?php esc_html_e( 'Sticky or Fixed Banner', 'sitewide-sales' ); ?></option>
+							<option value="hide" <?php selected( $cur_sale->get_meta_value('swsales_banner_scroll_behavior'), 'hide' ); ?>><?php esc_html_e( 'Magic Hide and Show on Scroll', 'sitewide-sales' ); ?></option>
+						</select>
+						<p class="description"><?php esc_html_e( 'Select how the banner appears when the user scrolls on page.', 'sitewide-sales' ); ?></p>
+					</td>
+				</tr>
+				<tr>
 					<?php
 						$checked_modifier = $cur_sale->get_hide_on_checkout() ? ' checked' : '';
 					?>
@@ -701,6 +722,14 @@ class SWSales_MetaBoxes {
 
 		if ( isset( $_POST['swsales_banner_module'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_module', sanitize_text_field( $_POST['swsales_banner_module'] ) );
+		}
+
+		if ( isset( $_POST['swsales_banner_close_behavior'] ) ) {
+			update_post_meta( $post_id, 'swsales_banner_close_behavior', sanitize_text_field( $_POST['swsales_banner_close_behavior'] ) );
+		}
+
+		if ( isset( $_POST['swsales_banner_scroll_behavior'] ) ) {
+			update_post_meta( $post_id, 'swsales_banner_scroll_behavior', sanitize_text_field( $_POST['swsales_banner_scroll_behavior'] ) );
 		}
 
 		if ( ! empty( $_POST['swsales_hide_on_checkout'] ) ) {

--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -26,7 +26,7 @@ class SWSales_MetaBoxes {
 	public static function enqueue_scripts() {
 		global $wpdb, $typenow;
 		if ( 'sitewide_sale' === $typenow ) {
-			wp_register_script( 'swsales_cpt_meta', plugins_url( 'js/swsales-cpt-meta.js', SWSALES_BASENAME ), array( 'jquery' ), '1.0.4' );
+			wp_register_script( 'swsales_cpt_meta', plugins_url( 'js/swsales-cpt-meta.js', SWSALES_BASENAME ), array( 'jquery' ), SWSALES_VERSION );
 			wp_enqueue_script( 'swsales_cpt_meta' );
 
 			$pages_with_swsales_shortcode = $wpdb->get_col(

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -275,6 +275,7 @@ class SWSales_Reports {
 		$swsales_data = array(
 			'landing_page'      => ! empty( $landing_page_post_id ) && is_page( $landing_page_post_id ),
 			'sitewide_sale_id'  => $active_sitewide_sale->get_id(),
+			'banner_close_behavior'  => $active_sitewide_sale->get_banner_close_behavior(),
 			'ajax_url'          => admin_url( 'admin-ajax.php' ),
 		);
 

--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -412,12 +412,25 @@ class SWSales_Sitewide_Sale {
 	}
 
 	/**
-	 * Returns landing page template
+	 * Returns the banner text
 	 *
 	 * @return string
 	 */
 	public function get_banner_text() {
 		return $this->banner_text;
+	}
+
+	/**
+	 * Returns how the banner should be handled after closing
+	 *
+	 * @return bool
+	 */
+	public function get_banner_close_behavior() {
+		if ( isset( $this->post_meta['swsales_banner_close_behavior'] ) ) {
+			return $this->post_meta['swsales_banner_close_behavior'];
+		} else {
+			return 'refresh';
+		}
 	}
 
 	/**

--- a/js/swsales-tracking.js
+++ b/js/swsales-tracking.js
@@ -19,35 +19,69 @@ function swsales_set_tracking_cookie(cookie_array) {
 
 function swsales_send_ajax(report) {
 	jQuery.post(
-    swsales.ajax_url, 
-    {
-        'action': 'swsales_ajax_tracking',
-        'report': report,
-				'sitewide_sale_id': swsales.sitewide_sale_id
-    }, 
-    function(response) {
-        //console.log('The server responded: ', response);
-    }
-);
+	    swsales.ajax_url,
+	    {
+	        'action': 'swsales_ajax_tracking',
+	        'report': report,
+					'sitewide_sale_id': swsales.sitewide_sale_id
+	    },
+	    function(response) {
+	        //console.log('The server responded: ', response);
+	    }
+	);
+}
+
+function swsales_get_banner_cookie() {
+	var cookie_string = wpCookies.get( 'swsales_' + swsales.sitewide_sale_id + '_banner', '/' );
+	var cookie_array;
+	if ( null == cookie_string ) {
+		cookie_val = 0;
+	} else {
+		cookie_val = cookie_string;
+	}
+
+	return cookie_val;
+}
+
+function swsales_set_banner_cookie(cookie_val) {
+	var cookie_string = cookie_val;
+	wpCookies.set( 'swsales_' + swsales.sitewide_sale_id + '_banner', cookie_string, 0, '/' );
 }
 
 function swsales_track() {
-	var cookie = swsales_get_tracking_cookie();
+	var trackingcookie = swsales_get_tracking_cookie();
 	if ( jQuery( '.swsales-banner' ).length ) {
-		if ( cookie['banner'] == 0 ) {
-			cookie['banner'] = 1;
+		if ( trackingcookie['banner'] == 0 ) {
+			trackingcookie['banner'] = 1;
 			swsales_send_ajax( 'swsales_banner_impressions' );
-			swsales_set_tracking_cookie( cookie );
+			swsales_set_tracking_cookie( trackingcookie );
 		}
 	}
 
 	if ( swsales.landing_page == 1 ) {
-		if ( cookie['landing_page'] == 0 ) {
-			cookie['landing_page'] = 1;
+		if ( trackingcookie['landing_page'] == 0 ) {
+			trackingcookie['landing_page'] = 1;
 			swsales_send_ajax( 'swsales_landing_page_visits' );
-			swsales_set_tracking_cookie( cookie );
+			swsales_set_tracking_cookie( trackingcookie );
 		}
 	}
+
+	// Set cookie and hide or show banner based on sale settings.
+	if ( swsales.banner_close_behavior == 'session' ) {
+		var bannercookie = swsales_get_banner_cookie();
+		jQuery('.swsales-dismiss').on( 'click', function() {
+			bannercookie = 1;
+			swsales_set_banner_cookie( bannercookie );
+		});
+		if ( bannercookie == 1 ) {
+			jQuery('.swsales-banner').hide();
+		} else {
+			jQuery('.swsales-banner').show();
+		}
+	} else {
+		jQuery('.swsales-banner').show();
+	}
+
 }
 
 jQuery( document ).ready(

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -130,7 +130,7 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 
 				ob_start();
 				?>
-				<div id="swsales-banner-block-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner swsales-banner-block">
+				<div id="swsales-banner-block-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner swsales-banner-block" style="display: none;">
 					<?php
 						switch ( $name ) {
 							case 'show_top_banner':
@@ -300,13 +300,17 @@ style="display: none;"<?php } ?>>
 		$banner_info['module'] = $sitewide_sale->get_meta_value( 'swsales_banner_module' );
 		$banner_info['block_id'] = $sitewide_sale->get_meta_value( 'swsales_banner_block_id' );
 		$banner_info['location'] = $sitewide_sale->get_meta_value( 'swsales_banner_block_location' );
-
-		// If the blocks module is used, there is no template.
-		$banner_info['template'] = '';
 		// Update location in case we are previewing.
 		if ( ! is_admin() && current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_sale_banner_type'] ) ) {
 			$banner_info['location'] = $_REQUEST['swsales_preview_sale_banner_type'];
 		}
+
+		// If the blocks module is used, there is no template.
+		$banner_info['template'] = '';
+
+		$banner_info['close_behavior'] = $sitewide_sale->get_meta_value( 'swsales_banner_close_behavior' );
+		$banner_info['scroll_behavior'] = $sitewide_sale->get_meta_value( 'swsales_banner_scroll_behavior' );
+
 		return $banner_info;
 	}
 

--- a/modules/banner/blocks/swsales-banner-module-blocks-settings.js
+++ b/modules/banner/blocks/swsales-banner-module-blocks-settings.js
@@ -1,0 +1,46 @@
+jQuery( document ).ready(
+	function($) {
+		// create new reusable block banner AJAX
+		$( '#swsales_create_reusable_block_banner' ).click(
+			function() {
+				var data = {
+					'action': 'swsales_create_reusable_block_banner',
+					'swsales_id': $( '#post_ID' ).val(),
+					'swsales_reusable_block_banner_title': $( '#title' ).val(),
+					'nonce': swsales_blocks.create_reusable_block_banner_nonce,
+				};
+				$.post(
+					ajaxurl,
+					data,
+					function(response) {
+						response = $.parseJSON( response );
+						if (response.status == 'error' ) {
+							alert( response.error );
+						} else {
+							// success
+							$( '#swsales_banner_block_id' ).append( '<option value="' + response.post.ID + '">' + response.post.post_title + '</option>' );
+							$( '#swsales_banner_block_id' ).val( response.post.ID );
+						}
+					}
+				);
+			}
+		);
+
+		// toggling the reusable block input layout
+		function swsales_toggle_reusable_block_banner() {
+			var reusable_block_id = $( '#swsales_banner_block_id' ).val();
+			if (reusable_block_id == 0) {
+				$( '#swsales_after_reusable_block_select' ).hide();
+			} else {
+				$( '#swsales_edit_banner_block' ).attr( 'href', swsales.admin_url + 'post.php?post=' + reusable_block_id + '&action=edit' );
+				$( '#swsales_after_reusable_block_select' ).show();
+			}
+		}
+		$( '#swsales_banner_block_id' ).change(
+			function(){
+				swsales_toggle_reusable_block_banner();
+			}
+		);
+		swsales_toggle_reusable_block_banner();
+	}
+);

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -24,7 +24,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	public static function admin_enqueue_scripts() {
 		global $wpdb, $typenow;
 		if ( 'sitewide_sale' === $typenow ) {
-			wp_register_script( 'swsales_banner_module_swsales_settings', plugins_url( 'modules/banner/swsales/swsales-banner-module-swsales-settings.js', SWSALES_BASENAME ), array( 'jquery' ), '1.0.4' );
+			wp_register_script( 'swsales_banner_module_swsales_settings', plugins_url( 'modules/banner/swsales/swsales-banner-module-swsales-settings.js', SWSALES_BASENAME ), array( 'jquery' ), SWSALES_VERSION );
 			wp_enqueue_script( 'swsales_banner_module_swsales_settings' );
 		}
 	}
@@ -57,6 +57,11 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 			if ( Sitewide_Sales\classes\SWSales_Setup::is_login_page() ) {
 				$show_banner = false;
 			}
+		}
+
+		// If the banner module isn't custom, don't show the banner.
+		if ( isset( $banner_info['module'] ) && $banner_info['module'] != 'SWSales_Banner_Module_SWSales' ) {
+			$show_banner = false;
 		}
 
 		// Return nothing if we shouldn't show the banner.

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -147,7 +147,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 
 				ob_start();
 				?>
-				<div id="swsales-banner-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner">
+				<div id="swsales-banner-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner" style="display: none;">
 					<div class="swsales-banner-inner">
 						<?php
 						switch ( $name ) {
@@ -358,27 +358,6 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 				});
 			}
 		</script>
-		<tr>
-			<th scope="row" valign="top"><label><?php esc_html_e( 'Banner Close Behavior', 'sitewide-sales' ); ?></label></th>
-			<td>
-				<select class="swsales_option" id="swsales_banner_close_behavior" name="swsales_banner_close_behavior">
-					<option value="none" <?php selected( $banner_info['close_behavior'], 'none' ); ?>><?php esc_html_e( 'Close Until Refresh', 'sitewide-sales' ); ?></option>
-					<option value="refresh" <?php selected( $banner_info['close_behavior'], 'refresh' ); ?>><?php esc_html_e( 'Close Until New Session', 'sitewide-sales' ); ?></option>
-				</select>
-				<p class="description"><?php esc_html_e( 'Select when the banner will reappear if the user closes or dismisses the banner.', 'sitewide-sales' ); ?></p>
-			</td>
-		</tr>
-		<tr>
-			<th scope="row" valign="top"><label><?php esc_html_e( 'Page Scroll Behavior', 'sitewide-sales' ); ?></label></th>
-			<td>
-				<select class="swsales_option" id="swsales_banner_scroll_behavior" name="swsales_banner_scroll_behavior">
-					<option value="none" <?php selected( $banner_info['scroll_behavior'], 'none' ); ?>><?php esc_html_e( 'Default Banner Behavior', 'sitewide-sales' ); ?></option>
-					<option value="sticky" <?php selected( $banner_info['scroll_behavior'], 'none' ); ?>><?php esc_html_e( 'Sticky or Fixed Banner', 'sitewide-sales' ); ?></option>
-					<option value="hide" <?php selected( $banner_info['scroll_behavior'], 'hide' ); ?>><?php esc_html_e( 'Magic Hide and Show on Scroll', 'sitewide-sales' ); ?></option>
-				</select>
-				<p class="description"><?php esc_html_e( 'Select how the banner appears when the user scrolls on page.', 'sitewide-sales' ); ?></p>
-			</td>
-		</tr>
 		<?php
 	}
 
@@ -419,12 +398,6 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 		if ( isset( $_POST['swsales_banner_css'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_css', wp_kses_post( stripslashes( $_POST['swsales_banner_css'] ) ) );
 			delete_post_meta( $post_id, 'swsales_css_option' );
-		}
-		if ( isset( $_POST['swsales_banner_close_behavior'] ) ) {
-			update_post_meta( $post_id, 'swsales_banner_close_behavior', sanitize_text_field( $_POST['swsales_banner_close_behavior'] ) );
-		}
-		if ( isset( $_POST['swsales_banner_scroll_behavior'] ) ) {
-			update_post_meta( $post_id, 'swsales_banner_scroll_behavior', sanitize_text_field( $_POST['swsales_banner_scroll_behavior'] ) );
 		}
 	}
 


### PR DESCRIPTION
AJAX to insert a new reusable block if the banner module chosen is "Reusable Block".

Updated JS enqueues to use constant for plugin version.

Updated custom banner module and block banner module to hide if the active sale or previewed sale module type isn't that type. This prevents cases where the previewed banner has both a reusable block ID set and a custom module's default text set.

Rigged up the logic for banner close behavior to respect closing for the session or come back on all page refreshes/reloads. We should figure out a way for these settings to be on the module probably or at least consider how to connect those settings to popupmaker.