### PR TITLE
Reorder block positions; hook all blocks into wp_body_open; new default content for reusable block insert

### DIFF
--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -105,13 +105,13 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 	public static function __callStatic( $name, $arguments ) {
 		switch ( $name ) {
 			case 'hook_top_banner':
-				add_action( 'wp_head', array( __CLASS__, 'show_top_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_top_banner' ) );
 				break;
 			case 'hook_bottom_banner':
-				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_bottom_banner' ) );
 				break;
 			case 'hook_bottom_right_banner':
-				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_right_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_bottom_right_banner' ) );
 				break;
 			case 'show_top_banner':
 			case 'show_bottom_banner':
@@ -321,17 +321,17 @@ style="display: none;"<?php } ?>>
 	 */
 	private static function get_registered_banners() {
 		$registered_banners = array(
-			'top'          => array(
-				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
-				'callback'      => array( __CLASS__, 'hook_top_banner' ),
+			'bottom_right' => array(
+				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
+				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
 			),
 			'bottom'       => array(
 				'option_title'  => __( 'Bottom of Site', 'sitewide-sales' ),
 				'callback'      => array( __CLASS__, 'hook_bottom_banner' ),
 			),
-			'bottom_right' => array(
-				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
-				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
+			'top'          => array(
+				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
+				'callback'      => array( __CLASS__, 'hook_top_banner' ),
 			),
 		);
 		return $registered_banners;
@@ -365,7 +365,7 @@ style="display: none;"<?php } ?>>
 		$reusable_block_banner_post_id = wp_insert_post(
 			array(
 				'post_title'    => $reusable_block_banner_title,
-				'post_content'  => '<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"white\",\"className\":\"swsales-padding\"} --><div class=\"wp-block-group swsales-padding has-white-color has-black-background-color has-text-color has-background\"><!-- wp:columns --><div class=\"wp-block-columns\"><!-- wp:column --><div class=\"wp-block-column\"><!-- wp:heading {\"textColor\":\"white\"} --><h2 class=\"has-white-color has-text-color\">Limited Time Offer</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Save 50% on your first year of membership!</p><!-- /wp:paragraph --><!-- wp:buttons --><div class=\"wp-block-buttons\"><!-- wp:button {\"width\":100} --><div class=\"wp-block-button has-custom-width wp-block-button__width-100\"><a class=\"wp-block-button__link\">Buy Now</a></div><!-- /wp:button --></div><!-- /wp:buttons --></div><!-- /wp:column --></div><!-- /wp:columns --></div><!-- /wp:group -->',
+				'post_content'  => '<!-- wp:group {\"backgroundColor\":\"black\",\"textColor\":\"white\",\"className\":\"swsales-padding\"} --><div class=\"wp-block-group swsales-padding has-white-color has-black-background-color has-text-color has-background\"><!-- wp:heading {\"level\":3,\"textColor\":\"white\"} --><h3 class=\"has-white-color has-text-color\">Limited Time Offer</h3><!-- /wp:heading --><!-- wp:paragraph --><p>Save 50% on your first year of membership!</p><!-- /wp:paragraph --><!-- wp:buttons --><div class=\"wp-block-buttons\"><!-- wp:button {\"width\":100} --><div class=\"wp-block-button has-custom-width wp-block-button__width-100\"><a class=\"wp-block-button__link\">Buy Now</a></div><!-- /wp:button --></div><!-- /wp:buttons --></div><!-- /wp:group -->',
 				'post_type'     => 'wp_block',
 				'post_status'   => 'publish',
 			)

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -121,13 +121,13 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	public static function __callStatic( $name, $arguments ) {
 		switch ( $name ) {
 			case 'hook_top_banner':
-				add_action( 'wp_head', array( __CLASS__, 'show_top_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_top_banner' ) );
 				break;
 			case 'hook_bottom_banner':
-				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_bottom_banner' ) );
 				break;
 			case 'hook_bottom_right_banner':
-				add_action( 'wp_footer', array( __CLASS__, 'show_bottom_right_banner' ) );
+				add_action( 'wp_body_open', array( __CLASS__, 'show_bottom_right_banner' ) );
 				break;
 			case 'show_top_banner':
 			case 'show_bottom_banner':
@@ -455,15 +455,16 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	private static function get_registered_banners() {
 
 		$registered_banners = array(
-			'top'          => array(
-				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
-				'callback'      => array( __CLASS__, 'hook_top_banner' ),
+			'bottom_right' => array(
+				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
+				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
 				'css_selectors' => array(
-					'#swsales-banner-top',
-					'#swsales-banner-top .swsales-banner-title',
-					'#swsales-banner-top .swsales-banner-content',
-					'#swsales-banner-top .swsales-banner-button-wrap',
-					'#swsales-banner-top .swsales-banner-button',
+					'#swsales-banner-bottom-right',
+					'#swsales-banner-bottom-right .swsales-dismiss',
+					'#swsales-banner-bottom-right .swsales-banner-title',
+					'#swsales-banner-bottom-right .swsales-banner-content',
+					'#swsales-banner-bottom-right .swsales-banner-button-wrap',
+					'#swsales-banner-bottom-right .swsales-banner-button',
 				),
 			),
 			'bottom'       => array(
@@ -481,16 +482,15 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 					'#swsales-banner-bottom .swsales-banner-inner-right',
 				),
 			),
-			'bottom_right' => array(
-				'option_title'  => __( 'Bottom Right of Site', 'sitewide-sales' ),
-				'callback'      => array( __CLASS__, 'hook_bottom_right_banner' ),
+			'top'          => array(
+				'option_title'  => __( 'Top of Site', 'sitewide_Sales' ),
+				'callback'      => array( __CLASS__, 'hook_top_banner' ),
 				'css_selectors' => array(
-					'#swsales-banner-bottom-right',
-					'#swsales-banner-bottom-right .swsales-dismiss',
-					'#swsales-banner-bottom-right .swsales-banner-title',
-					'#swsales-banner-bottom-right .swsales-banner-content',
-					'#swsales-banner-bottom-right .swsales-banner-button-wrap',
-					'#swsales-banner-bottom-right .swsales-banner-button',
+					'#swsales-banner-top',
+					'#swsales-banner-top .swsales-banner-title',
+					'#swsales-banner-top .swsales-banner-content',
+					'#swsales-banner-top .swsales-banner-button-wrap',
+					'#swsales-banner-top .swsales-banner-button',
 				),
 			),
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Reordering the three placements for a banner to be bottom right, bottom, top.
- Changing reusable block banner and custom banner to use the wp_body_open hook to load banners always. This prevents some oddities with the block editor inline styles + is the preferred widely supporte core WP hook that 80% of themes in the directory have present.