### PR TITLE
Adding block patterns for fancy coupon and gradient templates

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -38,6 +38,36 @@ if ( function_exists( 'get_default_block_categories' ) ) {
 }
 
 /**
+ * Register a dashed border block style
+ */
+$dashed_border_block_types = array( 'core/heading', 'core/paragraph' );
+foreach ( $dashed_border_block_types as $dashed_border_block_type ) {
+	register_block_style(
+		$dashed_border_block_type,
+		array(
+			'name'         => 'dashed-border',
+			'label'        => __( 'Dashed Border', 'sitewide-sales' ),
+			'inline_style' => '.is-style-dashed-border { border: 2px dashed; padding: 1px 3px; }',
+		)
+	);
+}
+
+/**
+ * Register a highlighted background block style
+ */
+$highlight_block_types = array( 'core/heading', 'core/paragraph' );
+foreach ( $highlight_block_types as $highlight_block_type ) {
+	register_block_style(
+		$highlight_block_type,
+		array(
+			'name'         => 'highlight',
+			'label'        => __( 'Highlight', 'sitewide-sales' ),
+			'inline_style' => '.is-style-highlight { background: rgba( 255, 255, 255, 0.3 ); padding: 1px 3px; }',
+		)
+	);
+}
+
+/**
  * Enqueue block editor only JavaScript and CSS
  */
 function swsales_block_editor_scripts() {

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -52,7 +52,21 @@
 
 /* Reusable Block Banner Styles */
 .swsales-banner-block .swsales-padding > div {
-	padding: 15px;
+	padding: 20px 15px;
+}
+.swsales-banner-block .swsales-padding > *,
+.swsales-banner-block .wp-block-group > *,
+.swsales-banner-block .wp-block-column > * {
+	margin-top: 0;
+}
+.swsales-banner-block .swsales-padding *:last-child,
+.swsales-banner-block .wp-block-group *:last-child,
+.swsales-banner-block .wp-block-column *:last-child {
+	margin-bottom: 0;
+}
+.swsales-banner-block .wp-block-group,
+.swsales-banner-block .wp-block-group.has-background {
+	padding: 20px 15px;
 }
 .swsales-banner-block a.swsales-dismiss:before {
 	background-color: rgba( 255, 255, 255, 0.7 );
@@ -149,7 +163,7 @@
 	padding: 20px 15px;
 	position: fixed;
 	right: 0;
-	max-width: 300px;
+	max-width: 370px;
 	z-index: 400;
 }
 #swsales-banner-block-bottom-right {
@@ -157,7 +171,7 @@
 	box-shadow: 0 0 15px 0 rgba( 0, 0, 0, 0.6 );
 	position: fixed;
 	right: 0;
-	max-width: 330px;
+	max-width: 370px;
 	z-index: 400;
 }
 #swsales-banner-bottom-right a.swsales-dismiss,

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -10,6 +10,9 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 		add_action( 'wp_ajax_swsales_create_reusable_block_banner', array( __CLASS__, 'create_reusable_block_banner_ajax' ) );
 
+		// Set up block patterns.
+		add_action( 'init', array( __CLASS__, 'register_block_patterns' ) );
+
 		// Set up showing banner on frontend.
 		add_action( 'wp', array( __CLASS__, 'choose_banner' ) );
 	}
@@ -386,5 +389,63 @@ style="display: none;"<?php } ?>>
 		echo json_encode( $r );
 		exit;
 	}
+
+	/**
+	 * Handles registering all the built-in block patterns for reusable block banners.
+	 */
+	public static function register_block_patterns() {
+		// Create the block pattern category for sale banners.
+		register_block_pattern_category(
+			'swsalesbanners',
+			array(
+				'label' => __( 'Sale Banners', 'sitewide-sales' )
+			)
+		);
+
+		// Fancy Coupon Banner
+		register_block_pattern(
+			'swsales/fancy-coupon-banner',
+			array(
+				'title' => __( 'Fancy Coupon Banner', 'sitewide-sales' ),
+				'description' => _x( 'Sale callout with bright background, coupon code highlight, and a button to start shopping.', 'Block pattern description', 'sitewide-sales' ),
+				'content' => "<!-- wp:group {\"style\":{\"color\":{\"background\":\"#ffd001\"}}} -->\n<div class=\"wp-block-group has-background\" style=\"background-color:#ffd001\"><!-- wp:group {\"align\":\"wide\",\"textColor\":\"black\",\"layout\":{\"type\":\"flex\",\"flexWrap\":\"wrap\",\"justifyContent\":\"center\"}} -->\n<div class=\"wp-block-group alignwide has-black-color has-text-color\"><!-- wp:paragraph {\"className\":\"is-style-highlight\"} -->\n<p class=\"is-style-highlight\"><strong>You're so fancy.</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Save 50% on everything in the store!</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Use code</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"is-style-dashed-border\"} -->\n<p class=\"is-style-dashed-border\"><strong>savebeauty</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:buttons -->\n<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"black\",\"textColor\":\"white\"} -->\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-white-color has-black-background-color has-text-color has-background\"><strong>Start Shopping</strong></a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons --></div>\n<!-- /wp:group --></div>\n<!-- /wp:group -->",
+				'categories' => array( 'swsalesbanners' )
+			)
+		);
+
+		// Fancy Coupon Popup
+		register_block_pattern(
+			'swsales/fancy-coupon-popup',
+			array(
+				'title' => __( 'Fancy Coupon Popup', 'sitewide-sales' ),
+				'description' => _x( 'Sale callout with bright background, coupon code highlight, and a button to start shopping.', 'Block pattern description', 'sitewide-sales' ),
+				'content' => "<!-- wp:group {\"style\":{\"color\":{\"background\":\"#ffd001\"}},\"textColor\":\"black\"} -->\n<div class=\"wp-block-group has-black-color has-text-color has-background\" style=\"background-color:#ffd001\"><!-- wp:group {\"textColor\":\"black\",\"layout\":{\"type\":\"default\"}} -->\n<div class=\"wp-block-group has-black-color has-text-color\"><!-- wp:heading {\"level\":3,\"textColor\":\"black\",\"className\":\"is-style-highlight\"} -->\n<h3 class=\"is-style-highlight has-black-color has-text-color\">You're so fancy.</h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Save 50% on everything in the store! Use code</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"align\":\"center\",\"className\":\"is-style-dashed-border\"} -->\n<p class=\"has-text-align-center is-style-dashed-border\"><strong>savebeauty</strong></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:buttons -->\n<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"black\",\"textColor\":\"white\",\"width\":100} -->\n<div class=\"wp-block-button has-custom-width wp-block-button__width-100\"><a class=\"wp-block-button__link has-white-color has-black-background-color has-text-color has-background\"><strong>Start Shopping</strong></a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons --></div>\n<!-- /wp:group --></div>\n<!-- /wp:group -->",
+				'categories' => array( 'swsalesbanners' )
+			)
+		);
+
+		// Gradient Banner
+		register_block_pattern(
+			'swsales/gradient-banner',
+			array(
+				'title' => __( 'Gradient Banner', 'sitewide-sales' ),
+				'description' => _x( 'Sale callout with gradient background, heading, text, and a call-to-action button displayed in two lines, vertically aligned.', 'Block pattern description', 'sitewide-sales' ),
+				'content' => "<!-- wp:group {\"gradient\":\"vivid-cyan-blue-to-vivid-purple\"} -->\n<div class=\"wp-block-group has-vivid-cyan-blue-to-vivid-purple-gradient-background has-background\"><!-- wp:columns {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-columns are-vertically-aligned-center\"><!-- wp:column {\"verticalAlignment\":\"center\",\"width\":\"66.66%\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\" style=\"flex-basis:66.66%\"><!-- wp:heading {\"level\":3,\"textColor\":\"white\"} -->\n<h3 class=\"has-white-color has-text-color\"><strong>50% Off Premium</strong></h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"textColor\":\"white\"} -->\n<p class=\"has-white-color has-text-color\">Don't miss out—this sale is fading fast. Use code <strong>FLASH</strong> now through November 30.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"verticalAlignment\":\"center\",\"width\":\"33.33%\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\" style=\"flex-basis:33.33%\"><!-- wp:buttons {\"layout\":{\"type\":\"flex\",\"justifyContent\":\"center\"}} -->\n<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"white\",\"width\":100,\"style\":{\"border\":{\"radius\":\"100px\"}}} -->\n<div class=\"wp-block-button has-custom-width wp-block-button__width-100\"><a class=\"wp-block-button__link has-white-background-color has-background\" style=\"border-radius:100px\"><strong>Join Today &amp; Save!</strong></a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns --></div>\n<!-- /wp:group -->",
+				'categories' => array( 'swsalesbanners' )
+			)
+		);
+
+		// Gradient Popup
+		register_block_pattern(
+			'swsales/gradient-popup',
+			array(
+				'title' => __( 'Gradient Popup', 'sitewide-sales' ),
+				'description' => _x( 'Sale callout with gradient background, heading, text, and a call-to-action button stacked for a popup display.', 'Block pattern description', 'sitewide-sales' ),
+				'content' => "<!-- wp:group {\"textColor\":\"white\",\"gradient\":\"vivid-cyan-blue-to-vivid-purple\"} -->\n<div class=\"wp-block-group has-white-color has-vivid-cyan-blue-to-vivid-purple-gradient-background has-text-color has-background\"><!-- wp:heading {\"level\":3,\"textColor\":\"white\",\"className\":\"is-style-default\"} -->\n<h3 class=\"is-style-default has-white-color has-text-color\"><strong>50% Off Premium</strong></h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"textColor\":\"white\"} -->\n<p class=\"has-white-color has-text-color\">Don't miss out—this sale is fading fast. Use code <strong>FLASH</strong> now through November 30.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:buttons -->\n<div class=\"wp-block-buttons\"><!-- wp:button {\"backgroundColor\":\"white\",\"textColor\":\"black\",\"width\":100,\"style\":{\"border\":{\"radius\":\"100px\"}}} -->\n<div class=\"wp-block-button has-custom-width wp-block-button__width-100\"><a class=\"wp-block-button__link has-black-color has-white-background-color has-text-color has-background\" style=\"border-radius:100px\"><strong>Join Today &amp; Save!</strong></a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons --></div>\n<!-- /wp:group -->",
+				'categories' => array( 'swsalesbanners' )
+			)
+		);
+	}
+
 }
 SWSales_Banner_Module_Blocks::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Added two block styles for a highlighted background and a dashed border. These are used in our block patterns and for building landing pages.
- Started adding block patterns for the sale banners. New block pattern group "Sale Banners" and four new patterns for the Fancy Coupon and Gradient templates in two locations.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* FEATURED: Built-in Block Patterns and Styles for Sale Banners.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
