### PR TITLE
Top banner close link; filter to hide dismiss link

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -71,6 +71,17 @@
 	text-align: center;
 	width: 100%;
 }
+#swsales-banner-top a.swsales-dismiss,
+#swsales-banner-block-top a.swsales-dismiss {
+	position: absolute;
+	top: 15px;
+	right: 15px;
+	z-index: 100;
+}
+.admin-bar #swsales-banner-top a.swsales-dismiss,
+.admin-bar #swsales-banner-block-top a.swsales-dismiss {
+	top: 47px;
+}
 #swsales-banner-top p {
 	margin: 0;
 	padding: 0;

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -134,7 +134,10 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 					<?php
 						switch ( $name ) {
 							case 'show_top_banner':
-								echo $banner_content;
+								?>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-top').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
+								<?php echo $banner_content; ?>
+								<?php
 								break;
 							case 'show_bottom_banner':
 								?>

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -127,29 +127,34 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 				// Get the banner content.
 				$banner_block = get_post( $banner_info['block_id'] );
 				$banner_content = do_blocks( $banner_block->post_content );
+				$banner_location_nicename = str_replace( '_', '-', $banner_info['location'] );
+
+				// The HTML to show the banner dismiss link.
+				$banner_dismiss_link_html = '<a href="javascript:void(0);" onclick="document.getElementById( "swsales-banner-block-' . esc_attr( $banner_location_nicename ) . '" ).style.display = "none";" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( "Dismiss", "sitewide-sales" ); ?></a>';
+
+				/**
+				 * Filter to disable or modify the banner dismiss link HTML.
+				 * Set to empty string to hide the link.
+				 *
+				 * @since 1.3.0
+				 *
+				 * @param string $banner_dismiss_link_html The full HTML of the banner dismiss link.
+				 * @param array $banner_info The full banner info for this banner.
+				 *
+				 * @return string $banner_dismiss_link_html The HTML to render.
+				 */
+				$banner_dismiss_link_html = apply_filters( 'swsales_banner_dismiss_link_html', $banner_dismiss_link_html, $banner_info );
 
 				ob_start();
 				?>
-				<div id="swsales-banner-block-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner swsales-banner-block" style="display: none;">
+				<div id="swsales-banner-block-<?php echo esc_attr( $banner_location_nicename ); ?>" class="swsales-banner swsales-banner-block" style="display: none;">
 					<?php
 						switch ( $name ) {
 							case 'show_top_banner':
-								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-top').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
-								<?php echo $banner_content; ?>
-								<?php
-								break;
 							case 'show_bottom_banner':
-								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-bottom').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
-								<?php echo $banner_content; ?>
-								<?php
-								break;
 							case 'show_bottom_right_banner':
-								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-block-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
-								<?php echo $banner_content; ?>								
-								<?php
+								echo $banner_dismiss_link_html;
+								echo $banner_content;
 								break;
 						}
 					?>

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -153,6 +153,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 						switch ( $name ) {
 							case 'show_top_banner':
 								?>
+								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-top').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'top', $active_sitewide_sale ); ?></p>
 								<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -138,6 +138,23 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 					$active_sitewide_sale = Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_active_sitewide_sale();
 				}
 				$banner_info = self::get_banner_info( $active_sitewide_sale );
+				$banner_location_nicename = str_replace( '_', '-', $banner_info['location'] );
+
+				// The HTML to show the banner dismiss link.
+				$banner_dismiss_link_html = '<a href="javascript:void(0);" onclick="document.getElementById( "swsales-banner-block-' . esc_attr( $banner_location_nicename ) . '" ).style.display = "none";" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( "Dismiss", "sitewide-sales" ); ?></a>';
+
+				/**
+				 * Filter to disable or modify the banner dismiss link HTML.
+				 * Set to empty string to hide the link.
+				 *
+				 * @since 1.3.0
+				 *
+				 * @param string $banner_dismiss_link_html The full HTML of the banner dismiss link.
+				 * @param array $banner_info The full banner info for this banner.
+				 *
+				 * @return string $banner_dismiss_link_html The HTML to render.
+				 */
+				$banner_dismiss_link_html = apply_filters( 'swsales_banner_dismiss_link_html', $banner_dismiss_link_html, $banner_info );
 
 				// Get the landing page URL.
 				$landing_page_id = $active_sitewide_sale->get_landing_page_post_id();
@@ -147,13 +164,13 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 
 				ob_start();
 				?>
-				<div id="swsales-banner-<?php esc_html_e( str_replace( '_', '-', $banner_info['location'] ) ); ?>" class="swsales-banner" style="display: none;">
+				<div id="swsales-banner-<?php echo esc_attr( $banner_location_nicename ); ?>" class="swsales-banner" style="display: none;">
 					<div class="swsales-banner-inner">
 						<?php
 						switch ( $name ) {
 							case 'show_top_banner':
+								echo $banner_dismiss_link_html;
 								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-top').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'top', $active_sitewide_sale ); ?></p>
 								<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>
@@ -166,8 +183,8 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								<?php
 								break;
 							case 'show_bottom_banner':
+								echo $banner_dismiss_link_html;
 								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<div class="swsales-banner-inner-left">
 									<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 									<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'bottom', $active_sitewide_sale ); ?></p>
@@ -184,8 +201,8 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 								<?php
 								break;
 							case 'show_bottom_right_banner':
+								echo $banner_dismiss_link_html;
 								?>
-								<a href="javascript:void(0);" onclick="document.getElementById('swsales-banner-bottom-right').style.display = 'none';" class="swsales-dismiss" title="Dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss', 'sitewide-sales' ); ?></a>
 								<p class="swsales-banner-title"><?php echo wp_kses_post( $banner_info['title'] ); ?></p>
 								<p class="swsales-banner-content"><?php echo apply_filters( 'swsales_banner_text', $banner_info['text'], 'bottom_right', $active_sitewide_sale ); ?></p>
 								<?php do_action( 'swsales_before_banner_button', $active_sitewide_sale ); ?>

--- a/templates/fancy-coupon/fancy-coupon.php
+++ b/templates/fancy-coupon/fancy-coupon.php
@@ -77,11 +77,14 @@ add_filter( 'swsales_banner_text', __NAMESPACE__ . '\swsales_banner_text_fancy_c
  */
 function swsales_landing_page_content_fancy_coupon( $content, $sitewide_sale ) {
 	$content_before = '<div id="swsales-landing-page-wrap-fancy_coupon" class="swsales-landing-page-wrap">';
-	$content_before .= '<div class="swsales-landing-page-fancy_coupon-coupon">';
-	$content_before .= '<h3><small>' . esc_html( 'USE CODE', 'sitewide-sales' ) . '</small><br />';
-	$content_before .= $sitewide_sale->get_coupon();
-	$content_before .= '</h3></div>';
-
+	// Add the coupon to template if it is set for this sale.
+	$coupon = $sitewide_sale->get_coupon();
+	if ( ! empty( $coupon ) ) {
+		$content_before .= '<div class="swsales-landing-page-fancy_coupon-coupon">';
+		$content_before .= '<h3><small>' . esc_html( 'USE CODE', 'sitewide-sales' ) . '</small><br />';
+		$content_before .= $coupon;
+		$content_before .= '</h3></div>';
+	}
 	$content_after = '</div>';
 
 	$content = $content_before . $content . $content_after;

--- a/templates/fancy-coupon/fancy-coupon.php
+++ b/templates/fancy-coupon/fancy-coupon.php
@@ -60,7 +60,10 @@ function swsales_banner_text_fancy_coupon( $content, $location, $active_sitewide
 	// Filter the content if the template is Fancy Coupon.
 	if ( $swsales_banner_template === 'fancy_coupon' ) {
 		$content_after = '<div class="swsales-banner-fancy_coupon-coupon">';
-		$content_after .= '<span class="swsales-coupon">' . $active_sitewide_sale->get_coupon() . '</span>';
+		$coupon = $active_sitewide_sale->get_coupon();
+		if ( ! empty( $coupon ) ) {
+			$content_after .= '<span class="swsales-coupon">' . $active_sitewide_sale->get_coupon() . '</span>';
+		}
 		$content_after .= '</div>';		
 		$content = $content . $content_after;
 	}

--- a/templates/gradient/banner.css
+++ b/templates/gradient/banner.css
@@ -12,6 +12,9 @@
 	margin-right: 15px;
 	padding-right: 15px;
 }
+#swsales-banner-wrap-gradient #swsales-banner-top .swsales-banner-button-wrap {
+	margin-left: 15px;
+}
 #swsales-banner-wrap-gradient .swsales-banner {
 	background: linear-gradient(270deg, #4bcf93, #4b79cf, #a24bcf);
 	background-size: 600% 600%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added top banner close button that respects the sale setting for show on refresh vs show on next session.

Close button on both custom module and the reusable block module.

Fixed a small bug where the fancy coupon banner would still show the dotted border even if the coupon wasn't set for the sale.

Fixed a small CSS improvement in the gradient template.

Added filter `swsales_banner_dismiss_link_html` so custom code can hide the banner. The filter includes the full HTML of the button to be rendered as well as the full banner_info so that custom code can hide the dismiss button for a specific banner ID or location.

See this gist for implementation of the filter: https://gist.github.com/kimcoleman/3701b7afb9b096b7709f857814cb8c7a

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Now supporting banner dismiss for the top banner location.
* ENHANCEMENT: Added filter `swsales_banner_dismiss_link_html` so custom code can hide or change the dismiss link on banners.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
