### PR TITLE
Improvements to reports based on issue 57 and more improvements

### DIFF
--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -143,56 +143,110 @@ class SWSales_Reports {
 			<?php
 			// Daily Revenue Chart.
 			// Build an array with each day of sale as a key to store revenue data in.
-			$date_array = array();
+			$date_array_all = array();
 			$period = new \DatePeriod(
 				new \DateTime( $sitewide_sale->get_start_date() ),
 				new \DateInterval('P1D'),
 				new \DateTime( $sitewide_sale->get_end_date() . ' + 1 day' )
 			);
 			foreach ($period as $key => $value) {
-				$date_array[ $value->format('Y-m-d') ] = 0.0;     
+				$date_array_all[ $value->format('Y-m-d') ] = 0.0;
 			}
 
+			/**
+			 * Filter the number of days shown in the report chart. Defauly is 31 days.
+			 */
+			$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
+			$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
+
 			$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', $date_array, $sitewide_sale );
-			if ( is_array( $daily_revenue_chart_data ) && $daily_revenue_chart_data !== $date_array ) {
-				?>
+
+			// Get the best day to highlight in the chart.
+			$highest_daily_revenue = max( $daily_revenue_chart_data );
+			if ( $highest_daily_revenue > 0 ) {
+				$highest_daily_revenue_key = array_search( $highest_daily_revenue, $daily_revenue_chart_data );
+			}
+
+			// Display the chart.
+			if ( is_array( $daily_revenue_chart_data ) ) { ?>
 				<hr>
-				<div id="chart_div" style="clear: both; width: 100%; height: 500px;"></div>
+				<div class="swsales_chart_area">
+					<div id="chart_div"></div>
+					<?php if ( count( $date_array_all ) > $daily_revenue_chart_days ) { ?>
+						<div class="swsales_chart_description"><p><center><em>
+							<?php esc_html_e( sprintf( __( 'This chart shows the last %s days of sale performance.', 'sitewide-sales' ), $daily_revenue_chart_days ) ); ?>
+						</em></center></p></div>
+					<?php } ?>
+				</div> <!-- end swsales_chart_area -->
 				<script>
 					// Draw the chart.
 					google.charts.load('current', {'packages':['corechart']});
 					google.charts.setOnLoadCallback(drawVisualization);
 					function drawVisualization() {
-
-						var data = google.visualization.arrayToDataTable([
-							[
-								{ label: 'DAY' },
-								{ label: 'Revenue' },
-							],
-							<?php foreach($daily_revenue_chart_data as $date => $value) { ?>
+						var dataTable = new google.visualization.DataTable();
+						dataTable.addColumn('string', <?php echo wp_json_encode( esc_html__( 'DAY', 'sitewide-sales' ) ); ?>);
+						dataTable.addColumn('number', <?php echo wp_json_encode( esc_html__( 'Sale Revenue', 'sitewide-sales' ) ); ?>);
+						dataTable.addColumn({type: 'string', role: 'style'});
+						dataTable.addColumn({type: 'string', role: 'annotation'});
+						dataTable.addRows([
+							<?php foreach( $daily_revenue_chart_data as $date => $value ) { ?>
 								[
-									'<?php echo esc_html( date_i18n( get_option('date_format'), strtotime( $date ) ) ); ?>',
-									<?php echo esc_html( $value );?>
+									<?php
+										echo wp_json_encode( esc_html( date_i18n( get_option('date_format'), strtotime( $date ) ) ) );
+									?>,
+									<?php echo wp_json_encode( (int) $value ); ?>,
+									<?php
+										if ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {
+											echo wp_json_encode( 'color: #5EC16C;' );
+										} else {
+											echo wp_json_encode( '' );
+										}
+									?>,
+									<?php
+										if ( ! empty( $highest_daily_revenue_key ) && $date === $highest_daily_revenue_key ) {
+											echo wp_json_encode( esc_html__( 'Best Day', 'sitewide-sales' ) );
+										} elseif ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {
+											echo wp_json_encode( esc_html__( 'Today', 'sitewide-sales' ) );
+										} else {
+											echo wp_json_encode( '' );
+										}
+									?>,
 								],
 							<?php } ?>
 						]);
-
 						var options = {
-							colors: ['#51a351'],
-							chartArea: {width: '90%'},
+							title: swsales_report_title(),
+							titlePosition: 'top',
+							titleTextStyle: {
+								color: '#555555',
+							},
+							legend: {position: 'none'},
+							colors: ['#31825D'],
+							chartArea: {
+								width: '90%',
+							},
 							hAxis: {
-								textStyle: {color: '#555555', fontSize: '12', italic: false},
-								maxAlternation: 1
+								textStyle: {
+									color: '#555555',
+									fontSize: '12',
+									italic: false,
+								},
 							},
 							vAxis: {
-								textPosition: 'none',
+								textStyle: {
+									color: '#555555',
+									fontSize: '12',
+									italic: false,
+								},
 							},
 							seriesType: 'bars',
-							series: {1: {type: 'line', color: 'red'}},
-							legend: {position: 'none'},
+							annotations: {
+								alwaysOutside: true,
+								stemColor : 'none',
+							},
 						};
 
-						<?php
+					<?php
 						$daily_revenue_chart_currency_format = array(
 							'currency_symbol' => '$',
 							'decimals' => 2,
@@ -208,11 +262,16 @@ class SWSales_Reports {
 							'fractionDigits': <?php echo intval( $daily_revenue_chart_currency_format['decimals'] ); ?>,
 							'groupingSymbol': '<?php echo esc_html( html_entity_decode( $daily_revenue_chart_currency_format['thousands_separator'] ) ); ?>',
 						});
-						formatter.format(data, 1);
+						formatter.format(dataTable, 1);
 
-						var chart = new google.visualization.ComboChart(document.getElementById('chart_div'));
-						chart.draw(data, options);
+						var chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
+						chart.draw(dataTable, options);
 					}
+
+					function swsales_report_title() {
+						return <?php echo wp_json_encode( esc_html( sprintf( __( 'Sale Revenue by Day for %s to %s.', 'sitewide-sales' ), $sitewide_sale->get_start_date(), $sitewide_sale->get_end_date() ) ) ); ?>;
+					}
+
 				</script>
 				<?php
 			}

--- a/css/admin.css
+++ b/css/admin.css
@@ -218,6 +218,22 @@
 	max-width: 500px;
 	width: 100%;
 }
+.swsales_chart_area {
+	background-color: #FFF;
+	clear: both;
+	margin: 0 0 40px 0;
+	padding: 0px 10px 10px 10px;
+}
+.swsales_chart_area rect[stroke-opacity] {
+	stroke-width: 0 !important;
+}
+.swsales_chart_area #chart_div {
+	clear: both;
+	height: 500px;
+	margin: 0 auto;
+	max-width: 1600px;
+}
+
 @media screen and (max-width: 768px) {
 	.swsales_reports-box {
 		margin: 0 1rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Updated chart to use our more modern implementation as coded in core PMPro.
* Added new features from feedback in Issue 57.
* Added filter `swsales_daily_revenue_chart_days` to limit days shown on chart to last 31 days (if sale is that long) by default.
* Now highlighting today and best day in the chart.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/sitewide-sales/issues/57.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Now showing 'Best Day' and 'Today' on the sale report chart.
* ENHANCEMENT: Added filter `swsales_daily_revenue_chart_days` to limit days shown on chart. Default is 31 days. 
