### PR TITLE
Elementor and Divi compatibility

### DIFF
--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Divi Compatibility
+ *
+ * @since 1.3.0
+ */
+
+class SWSalesDivi{
+
+	function __construct() {
+
+		if ( empty( $_GET['page'] ) || 'et_divi_role_editor' !== $_GET['page'] ) {
+			add_filter( 'et_builder_get_parent_modules', array( __CLASS__, 'toggle' ) );
+			add_filter( 'et_pb_module_content', array( __CLASS__, 'restrict_content' ), 10, 4 );
+			add_filter( 'et_pb_all_fields_unprocessed_et_pb_row', array( __CLASS__, 'row_settings' ) );
+			add_filter( 'et_pb_all_fields_unprocessed_et_pb_section', array( __CLASS__, 'section_settings' ) );			
+		}
+
+	}
+
+	public static function toggle( $modules ) {
+
+		if ( isset( $modules['et_pb_row'] ) && is_object( $modules['et_pb_row'] ) ) {
+			$modules['et_pb_row']->settings_modal_toggles['custom_css']['toggles']['sitewide-sale-period'] = __( 'Sitewide Sales', 'sitewide-sales' );
+		}
+
+		if ( isset( $modules['et_pb_section'] ) && is_object( $modules['et_pb_section'] ) ) {
+			$modules['et_pb_section']->settings_modal_toggles['custom_css']['toggles']['sitewide-sale-period'] = __( 'Sitewide Sales', 'sitewide-sales' );
+		}
+
+		return $modules;
+
+	}
+
+	public static function row_settings( $settings ) {
+
+		$settings['sitewide-sale-period'] = array(
+			'tab_slug' => 'custom_css',
+			'label' => __( 'Restrict Row by Sale Period', 'sitewide-sales' ),
+			'description' => __( 'Enter a sale period from these options: "pre-sale", "sale", and "post-sale".', 'sitewide-sales' ),
+			'type' => 'text',
+			'default' => '',
+			'option_category' => 'configuration',
+			'toggle_slug' => 'sitewide-sale-period',
+		);
+
+		return $settings;
+
+	}
+
+	public static function section_settings( $settings ) {
+
+		$settings['sitewide-sale-period'] = array(
+			'tab_slug' => 'custom_css',
+			'label' => __( 'Restrict Section by Sale Period', 'sitewide-sales' ),
+			'description' => __( 'Enter a sale period from these options: "pre-sale", "sale", and "post-sale".', 'sitewide-sales' ),
+			'type' => 'text',
+			'default' => '',
+			'option_category' => 'configuration',
+			'toggle_slug' => 'sitewide-sale-period',
+		);
+
+		return $settings;
+
+	}
+
+	public static function restrict_content( $output, $props, $attrs, $slug ) {
+
+		if ( et_fb_is_enabled() ) {
+			return $output;
+		}
+
+		if ( ! isset( $props['sitewide-sale-period'] ) ){
+			return $output;
+		}
+		
+		$sale_period_setting = $props['sitewide-sale-period'];
+		
+		if ( empty( trim( $sale_period_setting ) ) || trim( $sale_period_setting ) === '0' ) {
+			return $output;
+		}
+
+		// Assume content is visible.
+		$is_visible = true;
+
+		// Is this post a sale landing page? If so, load the sale.
+		$sitewide_sale_id = get_post_meta( get_queried_object_id(), 'swsales_sitewide_sale_id', true );
+		if ( ! empty( $sitewide_sale_id ) ) {
+			$sitewide_sale = new \Sitewide_Sales\classes\SWSales_Sitewide_Sale();
+			$sale_found = $sitewide_sale->get_sitewide_sale( $sitewide_sale_id );
+			$sitewide_sale = $sale_found;
+		}
+
+		// Or, try to load the active sale.
+		if ( empty( $sale_found ) ) {
+			$sitewide_sale = new \Sitewide_Sales\classes\SWSales_Sitewide_Sale();
+			$sale_found = $sitewide_sale->get_active_sitewide_sale();
+			$sitewide_sale = $sale_found;
+		}
+
+		// Still no sale? Return nothing and don't render the content.
+		if ( ! $sale_found ) {
+			return;
+		}
+
+		// Get the time period for the sale based on sale settings and current date.
+		$sale_period = $sitewide_sale->get_time_period();
+
+		// Allow admins to preview the sale period using a URL attribute.
+		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_time_period'] ) ) {
+			$sale_period = $_REQUEST['swsales_preview_time_period'];
+		}
+
+		// If the builder's setting for period does not match the sale period, set to false.
+		if ( $sale_period != $sale_period_setting ) {
+			$is_visible = false;
+		}
+
+		if ( ! empty( $is_visible ) ) {
+			return $output;
+		} else {
+			return '';
+		}
+	}
+
+}
+new SWSalesDivi();

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -5,7 +5,7 @@
  * @since 1.3.0
  */
 
-class SWSalesDivi{
+class SWSalesDivi {
 
 	function __construct() {
 

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Elementor Compatibility
+ */
+
+// Include custom settings to restrict Elementor widgets.
+require_once( 'elementor/class-swsales-elementor.php' );

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Elementor Compatibility
+ *
+ * @since 1.3.0
  */
 
 // Include custom settings to restrict Elementor widgets.

--- a/includes/compatibility/elementor/class-swsales-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-swsales-elementor-content-restriction.php
@@ -1,0 +1,149 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+use Elementor\Controls_Manager;
+
+class SWSales_Elementor_Sale_Content_Restriction extends SWSales_Elementor {
+	protected function sale_content_restriction() {
+		// Setup controls
+		$this->register_controls();
+
+		// Filter elementor render_content hook
+		add_action( 'elementor/widget/render_content', array( $this, 'swsales_elementor_render_content' ), 10, 2 );
+		add_action( 'elementor/frontend/section/should_render', array( $this, 'swsales_elementor_should_render' ), 10, 2 );
+	}
+
+	// Register controls to sections and widgets
+	protected function register_controls() {
+		foreach ( $this->locations as $where ) {
+			add_action('elementor/element/'.$where['element'].'/'.$this->section_name.'/before_section_end', array( $this, 'add_controls' ), 10, 2 );
+		}
+	}
+
+	// Define controls
+	public function add_controls( $element, $args ) {
+		$element->add_control(
+			'swsales_sale_period_heading', array(
+				'label' => __( 'Sale Period', 'sitewide-sales' ),
+				'type' => Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$element->add_control(
+			'swsales_sale_period', array(
+				'type'=> Controls_Manager::SELECT,
+				'options' => array(
+					'' => __( 'Always', 'sitewide-sales' ),
+					'pre-sale' => __( 'Before Sale', 'sitewide-sales' ),
+					'sale' => __( 'During Sale', 'sitewide-sales' ),
+					'post-sale' => __( 'After Sale', 'sitewide-sales' )
+				),
+				'label_block' => 'true',
+				'description' => __( 'Select the sale period this content is visible for.', 'sitewide-sales' ),
+			)
+		);
+	}
+
+	/**
+	 * Filter sections to render sale content or not.
+	 * If sale period doesn't match setting, hide the section.
+	 * @return boolean whether to show or hide section.
+	 * @since 1.3.0
+	 */
+	public function swsales_elementor_should_render( $should_render, $element ) {
+
+		// Don't hide content in editor mode.
+		if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+			return $should_render;
+		}
+
+		// Bypass if it's already hidden.
+		if ( $should_render === false ) {
+			return $should_render;
+		}
+		
+		// Checks if the element is restricted by sale period and whether it should show based on active sale period.
+		$should_render = $this->swsales_elementor_has_sale_period( $element );
+
+		return apply_filters( 'swsales_elementor_section_access', $should_render, $element );
+	}
+
+	/**
+	 * Filter individual content by sale period.
+	 * @return string Returns the content set from Elementor.
+	 * @since 1.3.0
+	 */
+	public function swsales_elementor_render_content( $content, $widget ){
+
+		// Don't hide content in editor mode.
+		if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+			return $content;
+		}
+
+		$show = $this->swsales_elementor_has_sale_period( $widget );
+		
+		if ( ! $show ) {
+			$content = '';
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Figure out if the active sale period is equal to the selected content period.
+	 * @return bool True or false based if the sale content should be shown or not.
+	 * @since 1.3.0
+	 */
+	public function swsales_elementor_has_sale_period( $element ) {
+
+		$element_settings = $element->get_active_settings();
+
+		$sale_period_setting = $element_settings['swsales_sale_period'];
+
+		// Just bail if the content isn't restricted by sale period at all.
+		if ( ! $sale_period_setting ) {
+			return true;
+		}
+
+		// Assume content is visible.
+		$is_visible = true;
+
+		// Is this post a sale landing page? If so, load the sale.
+		$sitewide_sale_id = get_post_meta( get_queried_object_id(), 'swsales_sitewide_sale_id', true );
+		if ( ! empty( $sitewide_sale_id ) ) {
+			$sitewide_sale = new \Sitewide_Sales\classes\SWSales_Sitewide_Sale();
+			$sale_found = $sitewide_sale->get_sitewide_sale( $sitewide_sale_id );
+			$sitewide_sale = $sale_found;
+		}
+
+		// Or, try to load the active sale.
+		if ( empty( $sale_found ) ) {
+			$sitewide_sale = new \Sitewide_Sales\classes\SWSales_Sitewide_Sale();
+			$sale_found = $sitewide_sale->get_active_sitewide_sale();
+			$sitewide_sale = $sale_found;
+		}
+
+		// Still no sale? Return nothing and don't render the inner blocks.
+		if ( ! $sale_found ) {
+			return;
+		}
+
+		// Get the time period for the sale based on sale settings and current date.
+		$sale_period = $sitewide_sale->get_time_period();
+
+		// Allow admins to preview the sale period using a URL attribute.
+		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_time_period'] ) ) {
+			$sale_period = $_REQUEST['swsales_preview_time_period'];
+		}
+		// If the block attributes period does not match the sale period, set to false.
+		if ( $sale_period != $sale_period_setting ) {
+			$is_visible = false;
+		}
+
+		return apply_filters( 'swsales_elementor_has_sale_period', $is_visible, $element, $sale_period );
+	}
+}
+
+new SWSales_Elementor_Sale_Content_Restriction;

--- a/includes/compatibility/elementor/class-swsales-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-swsales-elementor-content-restriction.php
@@ -125,7 +125,7 @@ class SWSales_Elementor_Sale_Content_Restriction extends SWSales_Elementor {
 			$sitewide_sale = $sale_found;
 		}
 
-		// Still no sale? Return nothing and don't render the inner blocks.
+		// Still no sale? Return nothing and don't render the content.
 		if ( ! $sale_found ) {
 			return;
 		}
@@ -137,7 +137,7 @@ class SWSales_Elementor_Sale_Content_Restriction extends SWSales_Elementor {
 		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_time_period'] ) ) {
 			$sale_period = $_REQUEST['swsales_preview_time_period'];
 		}
-		// If the block attributes period does not match the sale period, set to false.
+		// If the builder's setting for period does not match the sale period, set to false.
 		if ( $sale_period != $sale_period_setting ) {
 			$is_visible = false;
 		}

--- a/includes/compatibility/elementor/class-swsales-elementor.php
+++ b/includes/compatibility/elementor/class-swsales-elementor.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Add restriction options to Elementor Widgets For Sitewide Sales.
+ *
+ * @since 1.3.0
+ *
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+use Elementor\Controls_Manager;
+
+class SWSales_Elementor {
+    private static $_instance = null;
+
+    public $locations = array(
+        array(
+            'element' => 'common',
+            'action'  => '_section_style',
+        ),
+        array(
+            'element' => 'section',
+            'action'  => 'section_advanced',
+        )
+    );
+    public $section_name = 'swsales_elementor_section';
+
+	/**
+	 * Register new section for Sale Content.
+	 */
+	public function __construct() {
+        
+        require_once( __DIR__ . '/class-swsales-elementor-content-restriction.php' );
+        // Register new section to display restriction controls
+        $this->register_sections();
+
+        $this->sale_content_restriction();
+	}
+
+    /**
+     *
+     * Ensures only one instance of the class is loaded or can be loaded.
+     *
+     * @return SWSales_Elementor An instance of the class.
+     */
+    public static function instance() {
+        if ( is_null( self::$_instance ) )
+            self::$_instance = new self();
+
+        return self::$_instance;
+    }
+
+    private function register_sections() {
+        foreach( $this->locations as $where ) {
+            add_action( 'elementor/element/'.$where['element'].'/'.$where['action'].'/after_section_end', array( $this, 'add_section' ), 10, 2 );
+        }
+    }
+
+    public function add_section( $element, $args ) {
+        $exists = \Elementor\Plugin::instance()->controls_manager->get_control_from_stack( $element->get_unique_name(), $this->section_name );
+
+        if( ! is_wp_error( $exists ) )
+            return false;
+
+        $element->start_controls_section(
+            $this->section_name, array(
+                'tab'   => \Elementor\Controls_Manager::TAB_ADVANCED,
+                'label' => __( 'Sitewide Sales', 'sitewide-sales' ),
+            )
+        );
+
+        $element->end_controls_section();
+    }
+
+    protected function sale_content_restriction(){}
+}
+
+// Instantiate Plugin Class
+SWSales_Elementor::instance();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -108,3 +108,26 @@ function swsales_maybe_schedule_event( $timestamp, $recurrence, $hook, $args = a
         return false;
     }
 }
+
+/**
+ * Check if certain plugins or themes are installed and activated
+ * and if found dynamically load the relevant /includes/compatibility/ files.
+ */
+function swsales_compatibility_checker () {
+	$compat_checks = array(
+		array(
+			'file' => 'elementor.php',
+			'check_type' => 'constant',
+			'check_value' => 'ELEMENTOR_VERSION'
+		),
+	);
+
+	foreach ( $compat_checks as $key => $value ) {
+		if ( ( $value['check_type'] == 'constant' && defined( $value['check_value'] ) )
+		  || ( $value['check_type'] == 'function' && function_exists( $value['check_value'] ) )
+		  || ( $value['check_type'] == 'class' && class_exists( $value['check_value'] ) ) ) {
+			include( SWSALES_DIR . '/includes/compatibility/' . $value['file'] ) ;
+		}
+	}
+}
+add_action( 'plugins_loaded', 'swsales_compatibility_checker' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Added setting for "Sitewide Sales" to Elementor advanced settings.

You can now select a Sale Period for sections in Elementor to show before, during, and after your sale.
<img width="1185" alt="Screen Shot 2022-07-24 at 11 26 32 AM" src="https://user-images.githubusercontent.com/5312875/180654284-e799534d-f9ae-4930-9aa4-f5c37130c00a.png">

- Added setting for "Sitewide Sales" to Divi row and section settings.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* FEATURE: Now compatible with Elementor to build pages with sections based on sale period.
* FEATURE: Now compatible with Divi Builder and Divi Theme to restrict sections and rows based on sale period.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
