### PR TITLE
Fix for non english language sites to force DateTime in numeric formats only

### DIFF
--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -145,9 +145,9 @@ class SWSales_Reports {
 			// Build an array with each day of sale as a key to store revenue data in.
 			$date_array_all = array();
 			$period = new \DatePeriod(
-				new \DateTime( $sitewide_sale->get_start_date() ),
+				new \DateTime( $sitewide_sale->get_start_date( 'Y-m-d' ) ),
 				new \DateInterval('P1D'),
-				new \DateTime( $sitewide_sale->get_end_date() . ' + 1 day' )
+				new \DateTime( $sitewide_sale->get_end_date( 'Y-m-d' ) . ' + 1 day' )
 			);
 			foreach ($period as $key => $value) {
 				$date_array_all[ $value->format('Y-m-d') ] = 0.0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The bar chart report generated using an interval of time from start to end date. For sites using a date format that included a translated month name, the report page was throwing an error like:
`Uncaught Exception: DateTime::__construct(): Failed to parse time string (23 juin 2022) at position 0 (2): Unexpected character in /home/tacmnbts/public_html/wp-content/plugins/sitewide-sales/classes/class-swsales-reports.php:161`

This fixes the code to get the date interval to use numeric representation for the date range.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Change your site language to French
2. Make sure your WordPress Settings for date format include the month as a textual name representation
3. View a report screen.

With the new code in place, the same date range for the chart data is shown without an error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed error on report page for localized sites that use textual month name in date_format.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
