### PR TITLE
Adjusting the behavior for a site with no reusable blocks.

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -251,7 +251,7 @@ class SWSales_MetaBoxes {
 			$cur_sale->load_sitewide_sale( $post->ID );
 		}
 		?>
-		<p><?php esc_html_e( 'These fields control when the banner (if applicable) and built-in sale reporting will be active for your site. They also control what content is displayed on your sale Landing Page according to the "Landing Page" settings in Step 3 below.', 'sitewide-sales' ); ?></p>
+		<p><?php esc_html_e( 'These fields control when the banner (if applicable) and built-in sale reporting will be active for your site. They also control what content is displayed on your sale Landing Page according to the "Landing Page" settings below.', 'sitewide-sales' ); ?></p>
 
 		<table class="form-table">
 			<tbody>

--- a/modules/banner/blocks/class-swsales-banner-module-blocks.php
+++ b/modules/banner/blocks/class-swsales-banner-module-blocks.php
@@ -222,10 +222,10 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 		<tr>
 			<th scope="row" valign="top"><label><?php esc_html_e( 'Reusable Block', 'sitewide-sales' ); ?></label></th>
 			<td>
-				<?php
-					$block_found = false;
-					if ( $all_reusable_blocks->have_posts() ) { ?>
-						<select class="swsales_option" id="swsales_banner_block_id" name="swsales_banner_block_id">
+				<select class="swsales_option" id="swsales_banner_block_id" name="swsales_banner_block_id">
+					<?php
+						$block_found = false;
+						if ( $all_reusable_blocks->have_posts() ) { ?>
 							<option value="0"><?php esc_html_e( '- Choose One -', 'sitewide-sales' ); ?></option>
 							<?php
 								while ( $all_reusable_blocks->have_posts() ) {
@@ -240,21 +240,14 @@ class SWSales_Banner_Module_Blocks extends SWSales_Banner_Module {
 									}
 									echo '<option value="' . esc_attr( $all_reusable_blocks->post->ID ) . '"' . selected( $banner_info['block_id'], $all_reusable_blocks->post->ID ) . '>' . esc_html( $all_reusable_blocks->post->post_title ) . $status_part . '</option>';
 								}
-							?>
-						</select>
-					<?php
-						wp_reset_postdata();
+							wp_reset_postdata();
 						} else { ?>
-							<p><?php _e( 'Sorry, no posts matched your criteria.' ); ?></p>
-						<?php
-						}
+							<option id="swsales_banner_block_id_not_found" value="-1"><?php esc_html_e( 'No Blocks Found', 'sitewide-sales' ); ?></option>
+						<?php }
 					?>
+				</select>
 				<p>
-					<span id="swsales_after_reusable_block_select" 
-					<?php
-					if ( ! $block_found ) {
-						?>
-style="display: none;"<?php } ?>>
+					<span id="swsales_after_reusable_block_select">
 					<?php
 						$edit_block_url = admin_url( 'post.php?post=' . $banner_info['block_id'] . '&action=edit' );
 					?>

--- a/modules/banner/blocks/swsales-banner-module-blocks-settings.js
+++ b/modules/banner/blocks/swsales-banner-module-blocks-settings.js
@@ -30,11 +30,14 @@ jQuery( document ).ready(
 		// toggling the reusable block input layout
 		function swsales_toggle_reusable_block_banner() {
 			var reusable_block_id = $( '#swsales_banner_block_id' ).val();
-			if (reusable_block_id == 0) {
+			if (reusable_block_id == '-1') {
 				$( '#swsales_after_reusable_block_select' ).hide();
+				$( '#swsales_banner_block_id' ).prop( 'disabled', true );
 			} else {
+				$( '#swsales_banner_block_id' ).prop( 'disabled', false );
 				$( '#swsales_edit_banner_block' ).attr( 'href', swsales.admin_url + 'post.php?post=' + reusable_block_id + '&action=edit' );
 				$( '#swsales_after_reusable_block_select' ).show();
+				$( '#swsales_banner_block_id_not_found' ).remove();
 			}
 		}
 		$( '#swsales_banner_block_id' ).change(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If the site had no reusable blocks, the dropdown would hide and the message that nothing was found would show. Perfect.

But - the site would still show the "Edit" and "Save / Preview" buttons because the JS was checking for a 0 value which was actually undefined.

This PR generally improves that user experience - there is now a disabled select field shown when no blocks are found. the JS updates the options and enables the checkbox if you click the "create reusable block" button.

### Changelog entry

* BUG FIX: Improved UX for sites that have zero reusable blocks and want to create a new banner block for their sale.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
