### PR TITLE
Coupon date fixes

### DIFF
--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -206,7 +206,7 @@ class SWSales_Sitewide_Sale {
 			$start_date = $this->post_meta['swsales_start_date'];
 		} else {
 			// Get a new date.
-			$start_date = date( 'Y-m-d', strtotime( '+1 week', current_time( 'timestamp' ) ) ) . ' 23:59:59';
+			$start_date = date( 'Y-m-d', strtotime( '+1 week', current_time( 'timestamp' ) ) ) . ' 00:00:00';
 		}
 
 		return date_i18n( $dateformatstring, strtotime( $start_date ) );
@@ -241,7 +241,7 @@ class SWSales_Sitewide_Sale {
 			$end_date = $this->post_meta['swsales_end_date'];
 		} else {
 			// Get a new date.
-			$end_date = date( 'Y-m-d', strtotime( '+1 week', current_time( 'timestamp' ) ) ) . ' 23:59:59';
+			$end_date = date( 'Y-m-d', strtotime( '+2 weeks', current_time( 'timestamp' ) ) ) . ' 23:59:00';
 		}
 
 		return date_i18n( $dateformatstring, strtotime( $end_date ) );

--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -215,7 +215,7 @@ class SWSales_Module_EDD {
 			$coupon_code = strtoupper( substr( $scramble, 0, 10 ) );			
 		}
 
-		if( !class_exists('EDD_Discount' ) ){
+		if ( ! class_exists( 'EDD_Discount' ) ) {
 			return;
 		}
 		
@@ -228,8 +228,8 @@ class SWSales_Module_EDD {
 		$code->code = $coupon_code;
 		$code->type = $discount_type;
 		$code->amount = $amount;
-		$code->start = sanitize_text_field( $_REQUEST['swsales_start'] );
-		$code->expiration = sanitize_text_field( $_REQUEST['swsales_end'] );
+		$code->start = get_gmt_from_date( sanitize_text_field( $_REQUEST['swsales_start'] ), 'Y-m-d H:i:s' );
+		$code->expiration = get_gmt_from_date( sanitize_text_field( $_REQUEST['swsales_end'] ), 'Y-m-d H:i:s' );
 
 		$code->save();
 

--- a/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
+++ b/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
@@ -29,12 +29,8 @@ jQuery( document ).ready(
 				var data = {
 					'action': 'swsales_edd_create_coupon',
 					'swsales_edd_id': $( '#post_ID' ).val(),
-					'swsales_start': $( '#swsales_start_year' ).val() + '-'
-							 + $( '#swsales_start_month' ).val() + '-'
-							 + $( '#swsales_start_day' ).val(),
-					'swsales_end': $( '#swsales_end_year' ).val() + '-'
-							 + $( '#swsales_end_month' ).val() + '-'
-							 + $( '#swsales_end_day' ).val(),
+					'swsales_start': $( '#swsales_start_day' ).val() + ' ' + $( '#swsales_start_time' ).val() + ':00',
+					'swsales_end': $( '#swsales_end_day' ).val() + ' ' + $( '#swsales_end_time' ).val() + ':59',
 					'nonce': swsales_edd_metaboxes.create_coupon_nonce,
 				};
 				$.post(

--- a/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
+++ b/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
@@ -30,12 +30,8 @@ jQuery( document ).ready(
 				var data = {
 					'action': 'swsales_pmpro_create_discount_code',
 					'swsales_pmpro_id': $( '#post_ID' ).val(),
-					'swsales_start': $( '#swsales_start_year' ).val() + '-'
-							 + $( '#swsales_start_month' ).val() + '-'
-							 + $( '#swsales_start_day' ).val(),
-					'swsales_end': $( '#swsales_end_year' ).val() + '-'
-							 + $( '#swsales_end_month' ).val() + '-'
-							 + $( '#swsales_end_day' ).val(),
+					'swsales_start': $( '#swsales_start_day' ).val(),
+					'swsales_end': $( '#swsales_end_day' ).val(),
 					'nonce': swsales_pmpro_metaboxes.create_discount_code_nonce,
 				};
 				$.post(

--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -115,7 +115,7 @@ class SWSales_Module_WC {
 						<?php
 						if ( false !== $coupon_found ) {
 							$coupon_obj = new \WC_Coupon( $coupon_found->ID );
-							if ( null !== $coupon_obj->get_date_expires() && $cur_sale->get_end_date( 'Y-m-d H:i:s' ) < ( $coupon_obj->get_date_expires() )->date( 'Y-m-d H:i:s' ) ) {
+							if ( null !== $coupon_obj->get_date_expires() && $cur_sale->get_end_date( 'Y-m-d H:i:s' ) > $coupon_obj->get_date_expires()->date_i18n( 'Y-m-d' ) . ' 23:59:00' ) {
 								echo "<p id='swsales_wc_coupon_expiry_error' class='sitewide_sales_message sitewide_sales_error'>" . __( "This coupon expires on or before the Sitewide Sale's end date.", 'sitewide-sales' ) . '</p>';
 							}
 						}

--- a/modules/ecommerce/wc/swsales-module-wc-metaboxes.js
+++ b/modules/ecommerce/wc/swsales-module-wc-metaboxes.js
@@ -29,12 +29,8 @@ jQuery( document ).ready(
 				var data = {
 					'action': 'swsales_wc_create_coupon',
 					'swsales_wc_id': $( '#post_ID' ).val(),
-					'swsales_start': $( '#swsales_start_year' ).val() + '-'
-							 + $( '#swsales_start_month' ).val() + '-'
-							 + $( '#swsales_start_day' ).val(),
-					'swsales_end': $( '#swsales_end_year' ).val() + '-'
-							 + $( '#swsales_end_month' ).val() + '-'
-							 + $( '#swsales_end_day' ).val(),
+					'swsales_start': $( '#swsales_start_day' ).val(),
+					'swsales_end': $( '#swsales_end_day' ).val(),
 					'nonce': swsales_wc_metaboxes.create_coupon_nonce,
 				};
 				$.post(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When I swapped SWS to use a html date and time field for start and end dates, some of the expected old fields for day / month / year were still referenced in the code.

This PR also fixes the date check logic in the WooCommerce module, where dates were checking the inverse and sometimes slightly off because WC coupon codes don't support time.

This PR also fixes the "create discount code" feature for the EDD module to adjust the sale's dates back to UTC timestamp before sending to EDD, as this is how the EDD system stores dates. The EDD discounts page then displays them adjusted for the current timezone. So we want them to get the UTC date time and convert on their own site.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Improved discount/coupon date checks and automatic code creation across eCommerce modules.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
