### PR TITLE
Adjusting width for input text fields so the cpt admin page isn't wonky

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -108,10 +108,10 @@
 }
 
 /* Sitewide Sales Custom Post Type */
-.post-type-sitewide_sale input[type=text] {
+.post-type-sitewide_sale #poststuff input[type=text] {
 	width: 88%;
 }
-.post-type-sitewide_sale textarea {
+.post-type-sitewide_sale #poststuff textarea {
 	line-height: 1.4;
 	resize: vertical;
 	width: 88%;


### PR DESCRIPTION
Fixes this weird input on the all sitewide sales admin page.
<img width="1260" alt="Screen Shot 2022-09-17 at 9 17 05 AM" src="https://user-images.githubusercontent.com/5312875/190858957-9d848345-1d94-422f-a13f-e553fb7f3798.png">
