### PR TITLE
Allowing certain HTML in custom banner title and banner text.

### DIFF
--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -386,7 +386,6 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	 * @param WP_Post $post The post being saved.
 	 */
     protected static function save_banner_settings( $post_id, $post ) {
-    	global $allowedposttags;
 		if ( isset( $_POST['swsales_banner_location'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_location', sanitize_text_field( $_POST['swsales_banner_location'] ) );
 			delete_post_meta( $post_id, 'swsales_use_banner' );
@@ -397,14 +396,14 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 		}
 
 		if ( ! empty( $_POST['swsales_banner_title'] ) ) {
-			$swsales_banner_title = wp_kses( wp_unslash( $_POST['swsales_banner_title'] ), $allowedposttags );
+			$swsales_banner_title = wp_kses_post( wp_unslash( $_POST['swsales_banner_title'] ) );
 			update_post_meta( $post_id, 'swsales_banner_title', $swsales_banner_title );
 		} elseif ( isset( $_POST['swsales_banner_title'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_title', $post->post_title );
 		}
 
 		if ( isset( $_POST['swsales_banner_text'] ) ) {
-			$swsales_banner_text = wp_kses( wp_unslash( $_POST['swsales_banner_text'] ), $allowedposttags );
+			$swsales_banner_text = wp_kses_post( wp_unslash( $_POST['swsales_banner_text'] ) );
 			update_post_meta( $post_id, 'swsales_banner_text', $swsales_banner_text );
 		}
 

--- a/modules/banner/swsales/class-swsales-banner-module-swsales.php
+++ b/modules/banner/swsales/class-swsales-banner-module-swsales.php
@@ -305,14 +305,14 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 		<tr>
 			<th><label for="swsales_banner_title"><?php esc_html_e( 'Banner Title', 'sitewide-sales' ); ?></label></th>
 			<td>
-				<input type="text" name="swsales_banner_title" value="<?php echo esc_attr( $banner_info['title'] ); ?>">
+				<input type="text" name="swsales_banner_title" value="<?php echo stripslashes( $banner_info['title'] ); ?>">
 				<p class="description"><?php esc_html_e( 'A brief title for your sale, such as the holiday or purpose of the sale. (i.e. "Limited Time Offer")', 'sitewide-sales' ); ?></p>
 			</td>
 		</tr>
 		<tr>
 			<th><label for="swsales_banner_text"><?php esc_html_e( 'Banner Text', 'sitewide-sales' ); ?></label></th>
 			<td>
-				<textarea class="swsales_option" id="swsales_banner_text" name="swsales_banner_text"><?php echo esc_textarea( $banner_info['text'] ); ?></textarea>
+				<textarea class="swsales_option" id="swsales_banner_text" name="swsales_banner_text"><?php echo stripslashes( $banner_info['text'] ); ?></textarea>
 				<p class="description"><?php esc_html_e( 'A brief message about your sale. (i.e. "Save 50% on membership through December.")', 'sitewide-sales' ); ?></p>
 			</td>
 		</tr>
@@ -386,6 +386,7 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 	 * @param WP_Post $post The post being saved.
 	 */
     protected static function save_banner_settings( $post_id, $post ) {
+    	global $allowedposttags;
 		if ( isset( $_POST['swsales_banner_location'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_location', sanitize_text_field( $_POST['swsales_banner_location'] ) );
 			delete_post_meta( $post_id, 'swsales_use_banner' );
@@ -396,13 +397,15 @@ class SWSales_Banner_Module_SWSales extends SWSales_Banner_Module {
 		}
 
 		if ( ! empty( $_POST['swsales_banner_title'] ) ) {
-			update_post_meta( $post_id, 'swsales_banner_title', wp_kses_post( $_POST['swsales_banner_title'] ) );
+			$swsales_banner_title = wp_kses( wp_unslash( $_POST['swsales_banner_title'] ), $allowedposttags );
+			update_post_meta( $post_id, 'swsales_banner_title', $swsales_banner_title );
 		} elseif ( isset( $_POST['swsales_banner_title'] ) ) {
 			update_post_meta( $post_id, 'swsales_banner_title', $post->post_title );
 		}
 
 		if ( isset( $_POST['swsales_banner_text'] ) ) {
-			update_post_meta( $post_id, 'swsales_banner_text', sanitize_text_field( $_POST['swsales_banner_text'] ) );
+			$swsales_banner_text = wp_kses( wp_unslash( $_POST['swsales_banner_text'] ), $allowedposttags );
+			update_post_meta( $post_id, 'swsales_banner_text', $swsales_banner_text );
 		}
 
 		if ( ! empty( $_POST['swsales_banner_button_text'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change will allow the $allowedposttags html items in the banner title and banner text when building banners with the custom module.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Now accepting allowed html tags in the banner title and text when using the custom banner module.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
