### PR TITLE
Fix for case where the post meta sale ID isn't actually a sale CPT

### DIFF
--- a/classes/class-swsales-landing-pages.php
+++ b/classes/class-swsales-landing-pages.php
@@ -203,7 +203,11 @@ class SWSales_Landing_Pages {
 
 			// Load the sale.
 			$sitewide_sale = new SWSales_Sitewide_Sale();
-			$sitewide_sale->load_sitewide_sale( $sitewide_sale_id );
+			$sale_found = $sitewide_sale->load_sitewide_sale( $sitewide_sale_id );
+			// The ID we have isn't a Sitewide Sale CPT, return the content.
+			if ( ! $sale_found ) {
+				return $content;
+			}
 
 			// Get the time period for the sale based on sale settings and current date.
 			$sale_period = $sitewide_sale->get_time_period();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We had a weird edge case where the post had a custom field for sale ID that wasn't actually a SWS CPT, so it was still wrapping the content of the page in the swsales divs. This change fixes that case by first validating that the returned sale is a SWS sale.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Fixed edge case where a post meta field for sale ID was not a SWS CPT.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
