### PR TITLE
Adjusting logic to preview sale strike pricing to only apply when the sale preview period is set in URL parameter

### DIFF
--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -321,7 +321,7 @@ class SWSales_Module_WC {
 		$active_sitewide_sale = classes\SWSales_Sitewide_Sale::get_active_sitewide_sale();
 		
 		// If we're previewing a landing page, override the sale.
-		if ( ! empty( $_REQUEST['swsales_preview_time_period'] ) && current_user_can( 'administrator' ) ) {
+		if ( ! empty( $_REQUEST['swsales_preview_time_period'] ) && $_REQUEST['swsales_preview_time_period'] === 'sale' && current_user_can( 'administrator' ) ) {
 			$queried_object = get_queried_object();
 			if ( ! empty( $queried_object ) ) {
 				$landing_page_sale = classes\SWSales_Sitewide_Sale::get_sitewide_sale_for_landing_page( $queried_object->ID );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Jason did a PR to allow preview strike pricing when WooCommerce products are shown on an inactive sale.  This update makes sure that the preview period is "sale" so that the strike pricing and coupon logic is only previewed when the sale is active. This way people can put WooCommerce products on the pre-sale and post-sale views, preview how things look there, and they won't see their products on sale.

