### PR TITLE
Striking prices for variations similar to how we do for simple products.

### DIFF
--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -317,7 +317,7 @@ class SWSales_Module_WC {
 	 * @param  WC_Product $product that price is being generated for.
 	 * @return string     new price.
 	 */
-	public static function strike_prices( $price, $product ) {
+	public static function strike_prices( $price, $product ) {		
 		$active_sitewide_sale = classes\SWSales_Sitewide_Sale::get_active_sitewide_sale();
 		
 		// If we're previewing a landing page, override the sale.
@@ -361,8 +361,9 @@ class SWSales_Module_WC {
 		) {
 			$coupon = new \WC_Coupon( wc_get_coupon_code_by_id( $coupon_id ) );
 			if ( $coupon->is_valid_for_product( $product ) ) {
-				// Get pricing for simple products.
-				if ( $product->is_type( 'simple' ) ) {
+				// Get pricing for simple products and similar.
+				$simple_product_types = array( 'simple', 'variation' );
+				if ( $product->is_type( $simple_product_types ) ) {
 					$regular_price = get_post_meta( $product->get_id(), '_regular_price', true );
 					$discount_amount  = $coupon->get_discount_amount( $regular_price );
 					if ( $discount_amount > 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Before this update, when you chose a variation from the dropdown on the frontend, you would see the variation price like: <del>$10.00</del> $10.00. There was a strikethrough, but the sale price was not shown.

This update allows our strikethrough code to work on variations like it does on simple products (the variable products still show a range).

### How to test the changes in this Pull Request:

1. Create a variable product with a few variations.
2. Set up a coupon and SWS that applies to that product.
3. Visit the product on the frontend and choose a variation.

It should show the discounted price now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Now striking prices for variations similar to how we do for simple products.
