### PR TITLE
Support variation prices when there is no range and we want to reflect the discount.

### DIFF
--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -375,6 +375,8 @@ class SWSales_Module_WC {
 				}
 
 				// Get pricing for variable products.
+
+
 				if ( $product->is_type( 'variable' ) ) {
 					$prices           = $product->get_variation_prices( true );
 					$min_price        = current( $prices['price'] );
@@ -389,9 +391,15 @@ class SWSales_Module_WC {
 					$max_discounted_price = max( $max_price - $max_discount_amount, 0 );
 
 					if ( $min_discount_amount > 0 || $max_discount_amount > 0 ) {
-						$regular_range    = wc_format_price_range( $min_price, $max_price );
-						$discounted_range = wc_format_price_range( $min_discounted_price, $max_discounted_price );
-						$price            = '<del aria-hidden="true">' . $regular_range . '</del> <ins>' . $discounted_range . '</ins>';
+						if ( $min_price == $max_price && $min_discounted_price == $max_discounted_price ) {
+								// All variations are the same price. Show as a single price with strikethrough.
+								$price = '<del aria-hidden="true">' . wc_price( $min_price ) . '</del> <ins>' . wc_price( $min_discounted_price ) . '</ins>';
+						} else {
+							// Show variations as a range of prices with strikethrough range.
+							$regular_range    = wc_format_price_range( $min_price, $max_price );
+							$discounted_range = wc_format_price_range( $min_discounted_price, $max_discounted_price );
+							$price            = '<del aria-hidden="true">' . $regular_range . '</del> <ins>' . $discounted_range . '</ins>';
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A user reported that for variable products, it doesn't necessarily mean that the price is always a range. Sometimes all variations are the same price. We were incorrectly showing the range always if the product was variable.

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Improved display of WooCommerce variable price product when the price isn't a range.
* 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
