### PR TITLE
Adding new settings to hide the sale entirely by role or membership level

### DIFF
--- a/classes/class-swsales-metaboxes.php
+++ b/classes/class-swsales-metaboxes.php
@@ -314,6 +314,26 @@ class SWSales_MetaBoxes {
 				do_action( 'swsales_after_choose_sale_type', $cur_sale );
 				?>
 				<tr>
+					<th><label for="swsales_hide_sale_by_role"><?php esc_html_e( 'Hide Sale by Role', 'sitewide-sales' ); ?></label></th>
+					<td>
+						<input type="hidden" name="swsales_hide_sale_by_role_exists" value="1" />
+						<select multiple class="swsales_option" id="swsales_hide_sale_by_role_select" name="swsales_hide_sale_by_role[]">
+						<?php
+							$all_roles = get_editable_roles();
+							$all_roles['logged_out'] = array(
+								'name' => __( 'Logged Out', 'sitewide-sales' ),
+							);
+							$hide_for_roles = json_decode( $cur_sale->get_meta_value( 'swsales_hide_sale_by_role', '[]' ) );
+							foreach ( $all_roles as $slug => $role_data ) {
+								$selected_modifier = in_array( $slug, $hide_for_roles ) ? ' selected="selected"' : '';
+								echo '<option value="' . esc_attr( $slug ) . '"' . $selected_modifier . '>' . esc_html( $role_data['name'] ) . '</option>';
+							}
+						?>
+						</select>
+						<p class="description"><?php esc_html_e( 'This setting will hide the sale completely from users with the selected roles.', 'sitewide-sales' ); ?></p>
+					</td>
+				</tr>
+				<tr>
 					<th><label for="swsales_automatic_discount"><?php esc_html_e( 'Apply Discount Automatically', 'sitewide-sales' ); ?></label></th>
 					<td>
 						<select class="swsales_option" id="swsales_automatic_discount_select" name="swsales_automatic_discount">
@@ -705,6 +725,13 @@ class SWSales_MetaBoxes {
 
 		if ( isset( $_POST['swsales_sale_type'] ) ) {
 			update_post_meta( $post_id, 'swsales_sale_type', sanitize_text_field( $_POST['swsales_sale_type'] ) );
+		}
+
+		if ( ! empty( $_POST['swsales_hide_sale_by_role'] ) && is_array( $_POST['swsales_hide_sale_by_role'] )) {
+			$swsales_hide_sale_by_role = array_map( 'sanitize_text_field', $_POST['swsales_hide_sale_by_role'] );
+			update_post_meta( $post_id, 'swsales_hide_sale_by_role', wp_json_encode( $swsales_hide_sale_by_role ) );
+		} elseif ( ! empty( $_POST['swsales_hide_sale_by_role_exists'] ) ) {
+			update_post_meta( $post_id, 'swsales_hide_sale_by_role', wp_json_encode( array() ) );
 		}
 
 		if ( isset( $_POST['swsales_automatic_discount'] ) ) {

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -328,6 +328,10 @@ class SWSales_Reports {
 			return;
 		}
 
+		if ( null === $active_sitewide_sale->is_running() ) {
+			return;
+		}
+
 		wp_register_script( 'swsales_tracking', plugins_url( 'js/swsales.js', SWSALES_BASENAME ), array( 'jquery', 'utils' ) );
 
 		$landing_page_post_id = $active_sitewide_sale->get_landing_page_post_id();

--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -456,6 +456,36 @@ class SWSales_Sitewide_Sale {
 	}
 
 	/**
+	 * Whether the current sitewide sale should be hidden.
+	 *
+	 * @return string
+	 */
+	public function hide_sale() {
+		// Assume sale is visible to everyone.
+		$hide_sale = false;
+
+		// Get the meta value for roles this sale should be hidden for.
+		$hide_for_roles = json_decode( $this->get_meta_value( 'swsales_hide_sale_by_role', '' ) );
+
+		// If the hidden roles is an empty string, convert to an array.
+		$hide_for_roles = empty( $hide_for_roles ) ? array() : $hide_for_roles;
+
+		// Get the current user roles or if logged out, set the 'ghost' role.
+		if ( ! is_user_logged_in() ) {
+			$user_roles = array( 'logged_out' );
+		} else {
+			$user = wp_get_current_user();
+			$user_roles = ( array ) $user->roles;
+		}
+		// If this sale is hidden by role, check if the current user should see it.
+		if ( ! empty( $hide_for_roles ) && ! empty( array_intersect( $hide_for_roles, $user_roles ) ) ) {
+			$hide_sale = true;
+		}
+
+		return apply_filters( 'swsales_hide', $hide_sale, $this );
+	}
+
+	/**
 	 * Returns the number of times this sale's banner has been shown to unique users.
 	 *
 	 * @return int
@@ -527,7 +557,21 @@ class SWSales_Sitewide_Sale {
 	 * @return boolean
 	 */
 	public function is_running() {
-		return ( $this->is_active_sitewide_sale() && 'sale' === $this->get_time_period() );
+		// Don't check if the sale is hidden in the admin.
+		if ( is_admin() ) {
+			return ( $this->is_active_sitewide_sale() && 'sale' === $this->get_time_period() );
+		}
+
+		// Check whether the sale should be hidden for the current user.
+		$hide = $this->hide_sale();
+		
+		// If the sale is hidden for this user, return.
+		if ( $hide ) {
+			return;
+		} else {
+			return ( $this->is_active_sitewide_sale() && 'sale' === $this->get_time_period() );
+		}
+
 	}
 
 	/**

--- a/js/swsales-cpt-meta.js
+++ b/js/swsales-cpt-meta.js
@@ -10,6 +10,7 @@ jQuery( document ).ready(
 		}
 
 		// multiselects
+		$( "#swsales_hide_sale_by_role_select" ).selectWoo();
 		$( "#swsales_landing_page_select" ).selectWoo();
 		$( "#swsales_hide_banner_by_role_select" ).selectWoo();
 

--- a/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
+++ b/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
@@ -796,8 +796,10 @@ class SWSales_Module_PMPro {
 		// Get the meta value for levels this banner should be hidden for.
 		$hide_for_levels = json_decode( $sitewide_sale->get_meta_value( 'swsales_pmpro_hide_for_levels', '' ) );
 
-		// If the hidden levels is an empty string, convert to an array.
-		$hide_for_levels = empty( $hide_for_levels ) ? array() : $hide_for_levels;
+		// Return if there is no data for hiding banner by level.
+		if ( empty( $hide_for_levels ) ) {
+			return $show_banner;
+		}
 
 		// If this banner is hidden by level, check if the current user should see it.
 		if ( pmpro_hasMembershipLevel( $hide_for_levels ) ) {

--- a/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
+++ b/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
@@ -3,6 +3,7 @@ jQuery( document ).ready(
 
 		// multiselects
 		$( "#swsales_pmpro_discount_code_select" ).selectWoo();
+		$( "#swsales_pmpro_hide_sale_levels_select" ).selectWoo();
 		$( "#swsales_pmpro_hide_levels_select" ).selectWoo();
 
 		// toggling the discount code input layout


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds two new settings to hide the sale by role or by membership level. This will unset the sale's is_running check.

Also adjusted a check for displaying the banner if not hidden to any levels.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added setting to hide sale by membership level in PMPro module.
* ENHANCEMENT: Added setting to hide sale by role or for logged out users in all modules.
* BUG FIX: Fixed display issue with banner when not set to hide for any roles.
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
