### PR TITLE
Discount codes query optimized

### DIFF
--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -96,8 +96,12 @@ class SWSales_Module_EDD {
 			} else {
 
 				//Compatible with EDD 2.9 and 3.0
-				$coupons = edd_get_discounts( array( 'active' ) );
-
+				$coupons = edd_get_discounts(
+					array(
+						'fields' => array( 'id', 'code'),
+						'status' => 'active',
+					)
+				);
 				$current_coupon = intval( $cur_sale->get_meta_value( 'swsales_edd_coupon_id', null ) );
 				?>
 					<th><label for="swsales_edd_coupon_id"><?php esc_html_e( 'Discount Code', 'sitewide-sales' );?></label></th>
@@ -109,11 +113,11 @@ class SWSales_Module_EDD {
 							if( is_array( $coupons ) ){									
 								foreach ( $coupons as $coupon ) {
 									$selected_modifier = '';
-									if ( $coupon->ID === $current_coupon ) {
+									if ( (int)$coupon->id === $current_coupon ) {
 										$selected_modifier = ' selected="selected"';
 										$coupon_found      = $coupon;
 									}
-									echo '<option value="' . esc_attr( $coupon->ID ) . '"' . $selected_modifier . '>' . esc_html( $coupon->post_title ) . '</option>';
+									echo '<option value="' . esc_attr( $coupon->id ) . '"' . $selected_modifier . '>' . esc_html( $coupon->code ) . '</option>';
 								}
 							}
 							?>

--- a/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
+++ b/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
@@ -96,7 +96,11 @@ class SWSales_Module_PMPro {
 				<?php
 			} else {
 				global $wpdb;
-				$codes            = $wpdb->get_results( "SELECT * FROM $wpdb->pmpro_discount_codes", OBJECT );
+
+				// Query the database for the discount codes.
+				$codes = $wpdb->get_results( "SELECT * FROM $wpdb->pmpro_discount_codes", OBJECT );
+
+				// Get the discount code (if set) for the sale.
 				$current_discount = $cur_sale->get_meta_value( 'swsales_pmpro_discount_code_id', null );
 				?>
 					<th><label for="swsales_pmpro_discount_code_id"><?php esc_html_e( 'Discount Code', 'sitewide-sales' ); ?></label></th>

--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -88,7 +88,8 @@ class SWSales_Module_WC {
 				global $wpdb;
 
 				// Query the database for the coupons and only retrieve ID and post_title (coupon name).
-				$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM $wpdb->posts WHERE post_type = 'shop_coupon' AND post_status = 'publish'", OBJECT ) );
+				$coupon_limit = apply_filters( 'swsales_wc_coupon_limit', 5000 );
+				$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM $wpdb->posts WHERE post_type = 'shop_coupon' AND post_status = 'publish' LIMIT %d", $coupon_limit ), OBJECT );
 
 				// Get the current coupon (if set) for the sale.
 				$current_coupon = intval( $cur_sale->get_meta_value( 'swsales_wc_coupon_id', null ) );

--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -85,15 +85,12 @@ class SWSales_Module_WC {
 				</td>
 				<?php
 			} else {
-				$args = array(
-					'posts_per_page'   => -1,
-					'orderby'          => 'title',
-					'order'            => 'asc',
-					'post_type'        => 'shop_coupon',
-					'post_status'      => 'publish',
-				);
+				global $wpdb;
 
-				$coupons = get_posts( $args );
+				// Query the database for the coupons and only retrieve ID and post_title (coupon name).
+				$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT id, post_title FROM $wpdb->posts WHERE post_type = 'shop_coupon' AND post_status = 'publish'", OBJECT ) );
+
+				// Get the current coupon (if set) for the sale.
 				$current_coupon = intval( $cur_sale->get_meta_value( 'swsales_wc_coupon_id', null ) );
 				?>
 					<th><label for="swsales_wc_coupon_id"><?php esc_html_e( 'Coupon', 'sitewide-sales' );?></label></th>

--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -88,7 +88,7 @@ class SWSales_Module_WC {
 				global $wpdb;
 
 				// Query the database for the coupons and only retrieve ID and post_title (coupon name).
-				$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT id, post_title FROM $wpdb->posts WHERE post_type = 'shop_coupon' AND post_status = 'publish'", OBJECT ) );
+				$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM $wpdb->posts WHERE post_type = 'shop_coupon' AND post_status = 'publish'", OBJECT ) );
 
 				// Get the current coupon (if set) for the sale.
 				$current_coupon = intval( $cur_sale->get_meta_value( 'swsales_wc_coupon_id', null ) );
@@ -101,7 +101,7 @@ class SWSales_Module_WC {
 							$coupon_found = false;
 							foreach ( $coupons as $coupon ) {
 								$selected_modifier = '';
-								if ( $coupon->ID === $current_coupon ) {
+								if ( (int)$coupon->ID === $current_coupon ) {
 									$selected_modifier = ' selected="selected"';
 									$coupon_found      = $coupon;
 								}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We ran into issues using Sitewide Sales on a WooCommerce site that has over 30k discount codes. This update optimizes how we retrieve discount codes in the WC and EDD modules to only get the data we need for building the select field.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #138 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Optimized discount code queries in sale settings for EDD and WooCommerce modules.
* 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
