### PR TITLE
Prevent creating multiple pages, codes, and blocks when editing a Sitewide Sale

### DIFF
--- a/js/swsales-cpt-meta.js
+++ b/js/swsales-cpt-meta.js
@@ -54,6 +54,7 @@ jQuery( document ).ready(
 		// create new landing page AJAX
 		$( '#swsales_create_landing_page' ).click(
 			function() {
+				$( '#swsales_create_landing_page' ).attr( 'disabled', 'disabled' );
 				var data = {
 					'action': 'swsales_create_landing_page',
 					'swsales_id': $( '#post_ID' ).val(),

--- a/modules/banner/blocks/swsales-banner-module-blocks-settings.js
+++ b/modules/banner/blocks/swsales-banner-module-blocks-settings.js
@@ -3,6 +3,7 @@ jQuery( document ).ready(
 		// create new reusable block banner AJAX
 		$( '#swsales_create_reusable_block_banner' ).click(
 			function() {
+				$( '#swsales_create_reusable_block_banner' ).attr( 'disabled','disabled' );
 				var data = {
 					'action': 'swsales_create_reusable_block_banner',
 					'swsales_id': $( '#post_ID' ).val(),

--- a/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
+++ b/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
@@ -26,6 +26,7 @@ jQuery( document ).ready(
 		// create new coupon AJAX
 		$( '#swsales_edd_create_coupon' ).click(
 			function() {
+				$( '#swsales_edd_create_coupon' ).attr( 'disabled','disabled' );
 				var data = {
 					'action': 'swsales_edd_create_coupon',
 					'swsales_edd_id': $( '#post_ID' ).val(),

--- a/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
+++ b/modules/ecommerce/pmpro/swsales-module-pmpro-metaboxes.js
@@ -27,6 +27,7 @@ jQuery( document ).ready(
 		// create new discount code AJAX
 		$( '#swsales_pmpro_create_discount_code' ).click(
 			function() {
+				$( '#swsales_pmpro_create_discount_code' ).attr( 'disabled','disabled' );
 				var data = {
 					'action': 'swsales_pmpro_create_discount_code',
 					'swsales_pmpro_id': $( '#post_ID' ).val(),

--- a/modules/ecommerce/wc/swsales-module-wc-metaboxes.js
+++ b/modules/ecommerce/wc/swsales-module-wc-metaboxes.js
@@ -26,6 +26,7 @@ jQuery( document ).ready(
 		// create new coupon AJAX
 		$( '#swsales_wc_create_coupon' ).click(
 			function() {
+				$( '#swsales_wc_create_coupon' ).attr( 'disabled','disabled' );
 				var data = {
 					'action': 'swsales_wc_create_coupon',
 					'swsales_wc_id': $( '#post_ID' ).val(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Disable the "Create a new X" button" after it has been clicked on the "Edit Sitewide Sale" page to avoid situations where administrators create duplicate pages, codes, or blocks.

![screenshot_2023-08-04_at_9 35 48_am_480](https://github.com/strangerstudios/sitewide-sales/assets/24977505/8a0659ed-73a9-46d3-b8c9-b6975f1a2f65)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
