### PR TITLE
Fix fatal error for plugin meta settings and links.

### DIFF
--- a/classes/class-swsales-setup.php
+++ b/classes/class-swsales-setup.php
@@ -123,8 +123,10 @@ class SWSales_Setup {
 			$new_links = array(
 				'<a href="' . get_admin_url( null, 'edit.php?post_type=sitewide_sale' ) . '">' . __( 'View Sitewide Sales', 'sitewide-sales' ) . '</a>',
 			);
+
+			$links = array_merge( $new_links, $links );
 		}
-		return array_merge( $new_links, $links );
+		return $links;
 	}
 
 	/**


### PR DESCRIPTION
* BUG FIX: Fixes a fatal error when trying to add settings to plugin meta links for users that can view installed plugins but aren't admins.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
