### PR TITLE
Sitewide Sales Report to Compare Sales

### DIFF
--- a/adminpages/report-csv.php
+++ b/adminpages/report-csv.php
@@ -1,0 +1,146 @@
+<?php
+//only admins can get this
+if ( ! function_exists( "current_user_can" ) || ( ! current_user_can( "manage_options" ) ) ) {
+	die( __( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
+}
+
+//get values from form
+if(isset($_REQUEST['sitewide_sale'])) {
+	$id = sanitize_text_field($_REQUEST['sitewide_sale']);
+
+    $sitewide_sale =  \Sitewide_Sales\classes\SWSales_Sitewide_Sale::get_sitewide_sale( $id );
+    $start_date = $sitewide_sale->get_start_date();
+    $end_date = $sitewide_sale->get_end_date();
+    $banner_reach = $sitewide_sale->get_banner_impressions();
+    $landing_page_visits = $sitewide_sale->get_landing_page_visits();
+    $checkhouts_using_coupon = $sitewide_sale->get_checkout_conversions();
+    $sale_revenue = $sitewide_sale->get_revenue();
+    $other_new_revenue = $sitewide_sale->get_other_revenue();
+    if( $sitewide_sale->get_sale_type() == 'pmpro' ) {
+        $renewals = $sitewide_sale->get_renewal_revenue();
+    }
+	$total_revenue = $sitewide_sale->get_total_revenue();
+	$daily_revenue = $sitewide_sale->get_daily_revenue();
+
+}
+
+$headers   = array();
+$headers[] = "Content-Type: text/csv";
+$headers[] = "Cache-Control: max-age=0, no-cache, no-store";
+$headers[] = "Pragma: no-cache";
+$headers[] = "Connection: close";
+
+// Generate a filename based on the params.
+$filename = $sitewide_sale->get_name() . "_" . date( "Y-m-d_H-i", current_time( 'timestamp' ) ) . ".csv";
+$headers[] = "Content-Disposition: attachment; filename={$filename};";
+
+$left_header=   array (
+	"start date",
+	"end date",
+	"banner reach",
+	"landing page visits",
+	"checkhouts using coupon-" . $sitewide_sale->get_coupon(),
+	"sale revenue",
+	"other new revenue",
+	"total revenue in period"
+);
+
+if( $sitewide_sale->get_sale_type() == 'pmpro' ) {
+	array_push( $left_header,  "renewals" );
+}
+
+$csv_file_header_array = array_merge( $left_header, array_keys( $daily_revenue ) );
+
+$dateformat = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+
+// Generate a temporary file to store the data in.
+$tmp_dir  = apply_filters( 'pmpro_sales_report_csv_export_tmp_dir', sys_get_temp_dir() );
+
+$filename = tempnam( $tmp_dir, 'sws_reportcsv_' );
+
+// open in append mode
+$csv_fh = fopen( $filename, 'a' );
+
+//write the CSV header to the file
+fputcsv( $csv_fh, $csv_file_header_array);
+
+$csvoutput = array(
+	$start_date,
+	$end_date,
+	$banner_reach,
+	$landing_page_visits,
+	$checkhouts_using_coupon,
+	$sale_revenue,
+	$other_new_revenue,
+	$total_revenue		
+);
+
+if( $sitewide_sale->get_sale_type() == 'pmpro' ) {
+	array_push( $csvoutput, $renewals );
+}
+
+$csvoutput = array_merge( $csvoutput, array_values( $daily_revenue ) );
+		
+fputcsv( $csv_fh, $csvoutput );
+
+//flush the buffer
+wp_cache_flush();
+
+pmpro_transmit_report_data( $csv_fh, $filename, $headers );
+
+
+function pmpro_transmit_report_data( $csv_fh, $filename, $headers = array() ) {
+
+	//close the temp file
+	fclose( $csv_fh );
+
+	if ( version_compare( phpversion(), '5.3.0', '>' ) ) {
+
+		//make sure we get the right file size
+		clearstatcache( true, $filename );
+	} else {
+		// for any PHP version prior to v5.3.0
+		clearstatcache();
+	}
+
+	//did we accidentally send errors/warnings to browser?
+	if ( headers_sent() ) {
+		echo str_repeat( '-', 75 ) . "<br/>\n";
+		echo 'Please open a support case and paste in the warnings/errors you see above this text to\n ';
+		echo 'the <a href="http://paidmembershipspro.com/support/?utm_source=plugin&utm_medium=pmpro-sales-revenue-csv&utm_campaign=support" target="_blank">Paid Memberships Pro support forum</a><br/>\n';
+		echo str_repeat( "=", 75 ) . "<br/>\n";
+		echo file_get_contents( $filename );
+		echo str_repeat( "=", 75 ) . "<br/>\n";
+	}
+
+	//transmission
+	if ( ! empty( $headers ) ) {
+		//set the download size
+		$headers[] = "Content-Length: " . filesize( $filename );
+
+		//set headers
+		foreach ( $headers as $header ) {
+			header( $header . "\r\n" );
+		}
+
+		// disable compression for the duration of file download
+		if ( ini_get( 'zlib.output_compression' ) ) {
+			ini_set( 'zlib.output_compression', 'Off' );
+		}
+
+		if( function_exists( 'fpassthru' ) ) {
+			// use fpassthru to output the csv
+			$csv_fh = fopen( $filename, 'rb' );
+			fpassthru( $csv_fh );
+			fclose( $csv_fh );
+		} else {
+			// use readfile() if fpassthru() is disabled (like on Flywheel Hosted)
+			readfile( $filename );
+		}
+
+		// remove the temp file
+		unlink( $filename );
+	}
+
+	exit;
+}

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -15,7 +15,10 @@ class SWSales_Reports {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_tracking_js' ) );
 		add_action( 'wp_ajax_swsales_ajax_tracking', array( __CLASS__, 'ajax_tracking' ) );
 		add_action( 'wp_ajax_nopriv_swsales_ajax_tracking', array( __CLASS__, 'ajax_tracking' ) );
+		add_action("wp_ajax_sws_stats_csv", array(__CLASS__, "sws_stats_csv"));
 	}
+
+
 
 	public static function add_reports_page() {
 		add_submenu_page(
@@ -26,6 +29,36 @@ class SWSales_Reports {
 			'sitewide_sales_reports',
 			array( __CLASS__, 'show_reports_page' )
 		);
+	}
+
+	/**
+	 * Handles the Sales Export
+	 */
+	public static function sws_stats_csv() {
+		require_once(dirname(__FILE__) . "/../adminpages/report-csv.php");
+		exit;
+	}
+
+	/**
+	 * Gets a $csv_export_link for a sitewide sale.
+	 *
+	 * @param SWSales_Sitewide_Sale $sitewide_sale to get link for.
+	 * @return string $csv_export_link.
+	 * @since TBD.
+	 */
+	public static function build_CSV_report_link($sitewide_sale) {
+		//Bail if param is not correct.
+		if(! is_a( $sitewide_sale, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) ) {
+			return;
+		}
+		$csv_export_link = add_query_arg(
+			array(
+				'action' => 'sws_stats_csv',
+				'sitewide_sale' => $sitewide_sale->get_id(),
+			),
+			admin_url( 'admin-ajax.php' ) );
+
+		return esc_url( $csv_export_link );
 	}
 
 	public static function show_reports_page() { ?>
@@ -85,7 +118,11 @@ class SWSales_Reports {
 									}
 									?>
 								</select>
-							<?php } ?>
+								<?php if ($selected != null) { ?>
+									<a target="_blank" href="<?php echo SWSales_Reports::build_CSV_report_link( $selected ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'sitewide-sales' ); ?></a>
+						<?php	}
+							}
+						?>
 						</div>
 					</form>
 					<script>
@@ -187,7 +224,7 @@ class SWSales_Reports {
 			$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
 			$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
 
-			$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', $date_array, $sitewide_sale );
+			$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', 'N/A', $date_array, $sitewide_sale );
 
 			// Get the best day to highlight in the chart.
 			$highest_daily_revenue = max( $daily_revenue_chart_data );
@@ -306,7 +343,8 @@ class SWSales_Reports {
 			?>
 		</div>
 		<?php
-		do_action( 'swsales_additional_reports', $sitewide_sale );
+
+		do_action( 'swsales_additional_reports', array( $sitewide_sale ) );
 	}
 
 	/**
@@ -336,7 +374,7 @@ class SWSales_Reports {
 		$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
 		$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
 
-		$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', $date_array, $sitewide_sale );
+		$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', 'N/A', $date_array, $sitewide_sale );
 
 		// Get the best day to highlight in the chart.
 		$highest_daily_revenue = max( $daily_revenue_chart_data );
@@ -546,7 +584,7 @@ class SWSales_Reports {
 			}
 			?>
 		<?php
-		do_action( 'swsales_additional_reports', $sitewide_sale );
+		do_action( 'swsales_additional_reports', $sitewide_sales );
 	}
 
 	/**

--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -42,33 +42,51 @@ class SWSales_Reports {
 				);
 
 				// Choose sale to show.
-				$sale_to_show = null;
+				$sales_to_show = null;
 				if ( isset( $_REQUEST['sitewide_sale'] ) ) {
-					$sale_to_show = SWSales_Sitewide_Sale::get_sitewide_sale( $_REQUEST['sitewide_sale'] );
-				}
-				if ( null === $sale_to_show ) {
-					$sale_to_show = SWSales_Sitewide_Sale::get_active_sitewide_sale();
+					if ( is_array( $_REQUEST['sitewide_sale'] ) ) {
+						$sales_to_show = SWSales_Sitewide_Sale::get_sitewide_sales( $_REQUEST['sitewide_sale'] );
+					} else {
+						$sales_to_show = array ( 0 => SWSales_Sitewide_Sale::get_sitewide_sale( $_REQUEST['sitewide_sale'] ) );
+					}
+				} else {
+					$sales_to_show[0] =  SWSales_Sitewide_Sale::get_active_sitewide_sale();
 				}
 
-				// Select field to choose a sitewide sale.
 				if ( ! empty ( $all_sitewide_sales ) ) { ?>
 					<form method="get" action="/wp-admin/edit.php">
 						<input type="hidden" name="post_type" value="sitewide_sale" />
 						<input type="hidden" name="page" value="sitewide_sales_reports" />
-						<label for="sitewide_sale"><?php esc_html_e( 'Show reports for', 'sitewide-sales' ); ?></label>
-						<select id="swsales_select_report" name="sitewide_sale" onchange="this.form.submit()">
-							<?php
-							foreach ( $all_sitewide_sales as $sitewide_sale_id ) {
-									$sale              = SWSales_Sitewide_Sale::get_sitewide_sale( $sitewide_sale_id );
-									$selected_modifier = ( ! ( null === $sale_to_show ) && $sale->get_id() === $sale_to_show->get_id() ) ? 'selected="selected"' : '';
-								?>
-								<option value="<?php esc_attr_e( $sale->get_id() ); ?>" <?php echo( esc_html( $selected_modifier ) ); ?>>
-									<?php echo( esc_html( $sale->get_name() ) ); ?>
-								</option>
-								<?php
-							}
+						<div class="drops-wrapper">
+							<?php 
+
+							for ($i = 0; $i < 2; $i++) {
+								$class_modifier = ( $i === 0 ) ? 'left' : 'right';
+								$label_wording = ( $i === 0 ) ? 'Show reports for' : 'Vs.';
+								
+								$selected =  $sales_to_show !== null && array_key_exists( $i, $sales_to_show )  ? $sales_to_show[$i] : null;
 							?>
-						</select>
+								<label for="swsales_select_report_<?php echo $class_modifier ?>"><?php esc_html_e( $label_wording, 'sitewide-sales' ); ?></label>
+								<select id="swsales_select_report_<?php echo $class_modifier ?>"  name="sitewide_sale[]">
+									<?php
+									if($i == 1) {
+									?>
+									<option disabled selected value> -- select an option -- </option>
+									<?php
+									}
+									foreach ( $all_sitewide_sales as $sitewide_sale_id ) {
+										$sale   = SWSales_Sitewide_Sale::get_sitewide_sale( $sitewide_sale_id );
+										$selected_modifier =  $selected != null && $sale === $selected ? 'selected="selected"' : '';
+									?>
+										<option value="<?php esc_attr_e( $sale->get_id() ); ?>" <?php echo( esc_html( $selected_modifier ) ); ?>>
+											<?php echo( esc_html( $sale->get_name() ) ); ?>
+										</option>
+										<?php
+									}
+									?>
+								</select>
+							<?php } ?>
+						</div>
 					</form>
 					<hr />
 					<?php
@@ -78,8 +96,8 @@ class SWSales_Reports {
 				}
 
 				// Show report for sitewide sale if applicable.
-				if ( null !== $sale_to_show ) {
-					SWSales_Reports::show_report( $sale_to_show );
+				if ( $sales_to_show != null ) {
+					SWSales_Reports::show_report( $sales_to_show );
 				}
 			?>
 		</div> <!-- sitewide-sales_admin -->
@@ -87,144 +105,184 @@ class SWSales_Reports {
 	}
 
 	/**
+	 * Given a SWSales_Sitewide_Sale returns an Array with calculated data from it.
+	 * 
+	 * @param SWSales_Sitewide_Sale $sitewide_sale A  SWSales_Sitewide_Sale.
+	 * @return an Array with calculated data from a SWSales_Sitewide_Sale object.
+	 * @since TBD.
+	 * 
+	 */
+	public static function build_chart_data($sitewide_sale) {
+		// Daily Revenue Chart.
+		// Build an array with each day of sale as a key to store revenue data in.
+		$date_array_all = array();
+		$period = new \DatePeriod(
+			new \DateTime( $sitewide_sale->get_start_date( 'Y-m-d' ) ),
+			new \DateInterval('P1D'),
+			new \DateTime( $sitewide_sale->get_end_date( 'Y-m-d' ) . ' + 1 day' )
+		);
+		foreach ($period as $key => $value) {
+			$date_array_all[ $value->format('Y-m-d') ] = 0.0;
+		}
+
+		/**
+		* Filter the number of days shown in the report chart. Default is 31 days.
+		*/
+		$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
+		$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
+
+		$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', $date_array, $sitewide_sale );
+
+		// Get the best day to highlight in the chart.
+		$highest_daily_revenue = max( $daily_revenue_chart_data );
+		$highest_daily_revenue_key = $highest_daily_revenue > 0  ? array_search( $highest_daily_revenue, $daily_revenue_chart_data ) : null;
+
+		return  array ('daily_revenue_chart_data' => $daily_revenue_chart_data,
+		'date_array_all' => $date_array_all, 'highest_daily_revenue_key' => $highest_daily_revenue_key,
+		'daily_revenue_chart_days' => $daily_revenue_chart_days );
+	}
+
+	/**
 	 * Show report content for a Sitewide Sale.
 	 *
 	 * @param SWSales_Sitewide_Sale $sitewide_sale to show report for.
 	 */
-	public static function show_report( $sitewide_sale ) {
-		if ( ! is_a( $sitewide_sale, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) ) {
+	public static function show_report( $sitewide_sales ) {
+
+		$sale1 = $sitewide_sales[0];
+		if( count($sitewide_sales) > 1 ) {
+			$sale2 = $sitewide_sales[1];
+		}
+
+		if ( ! is_array( $sitewide_sales ) ) {
 			return;
 		}
-		?>
-		<div class="swsales_reports-box">
-			<h1 class="swsales_reports-box-title"><?php esc_html_e( 'Overall Sale Performance', 'sitewide-sales' ); ?></h1>
-			<p>
-			<?php
-				printf(
-					wp_kses_post( 'All visitors from %s to %s.', 'sitewide-sales' ),
-					esc_html( $sitewide_sale->get_start_date() ),
-					esc_html( $sitewide_sale->get_end_date() )
-				);
+
+		if (! is_a( $sale1 , 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) || 
+			( count( $sitewide_sales ) > 1 && ! is_a( $sale2, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) ) ) {
+				return;
+		}
 			?>
-			</p>
-			<hr />
-			<div class="swsales_reports-data swsales_reports-data-4col">
-				<div id="swsales_reports-data-section_banner" class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( $sitewide_sale->get_banner_impressions() ); ?></h1>
-					<p><?php esc_html_e( 'Banner Reach', 'sitewide-sales' ); ?></p>
-				</div>
-				<div id="swsales_reports-data-section_sales" class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( $sitewide_sale->get_landing_page_visits() ); ?></h1>
-					<p>
-						<?php
-							printf(
-								wp_kses_post( '<a href="%s" title="%s">Landing</a> Page Visits', 'sitewide-sales' ),
-								get_permalink( $sitewide_sale->get_landing_page_post_id() ),
-								get_the_title( $sitewide_sale->get_landing_page_post_id() )
-							);
-						?>
-					</p>
-				</div>
-				<div id="swsales_reports-data-section_sales" class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( $sitewide_sale->get_checkout_conversions() ); ?></h1>
-					<p>
-						<?php
-							printf(
-								wp_kses_post( apply_filters( 'swsales_checkout_conversions_title', __( 'Checkout Conversions', 'sitewide-sales' ), $sitewide_sale ) )
-							);
-						?>
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( $sitewide_sale->get_revenue() ); ?></h1>
-					<p><?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?></p>
-				</div>
-			</div>
-			<?php
-			// Daily Revenue Chart.
-			// Build an array with each day of sale as a key to store revenue data in.
-			$date_array_all = array();
-			$period = new \DatePeriod(
-				new \DateTime( $sitewide_sale->get_start_date( 'Y-m-d' ) ),
-				new \DateInterval('P1D'),
-				new \DateTime( $sitewide_sale->get_end_date( 'Y-m-d' ) . ' + 1 day' )
-			);
-			foreach ($period as $key => $value) {
-				$date_array_all[ $value->format('Y-m-d') ] = 0.0;
-			}
+		<div class="swsales_reports-box">
+			<table>
+				<tr>
+					<th>
+					</th>
+					<th>
+					<?php esc_html_e( 'Banner Reach', 'sitewide-sales' ); ?>
+					</th>
+					<th>
+						<?php esc_html_e( 'Landing Page Visits', 'sitewide-sales' ); ?>
+					</th>
+					<th>
+						<?php esc_html_e( 'Checkouts Using [coupon-code]', 'sitewide-sales' ); ?>
 
-			/**
-			 * Filter the number of days shown in the report chart. Defauly is 31 days.
-			 */
-			$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
-			$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
+					</th>
+					<th>
+						<?php esc_html_e( 'Revenue', 'sitewide-sales' ); ?>
+					</th>
+				</tr>
+				<tbody>
+					
+					<?php 
+					$ret = [];
+					foreach ($sitewide_sales as $sitewide_sale) { ?>
+						<tr>
+							<td>
+							<?php echo esc_attr( $sitewide_sale->get_name() ); ?>
+							</td>
+							<td>
+								<?php echo esc_attr( $sitewide_sale->get_banner_impressions() ); ?>
+							</td>
+							<td>
+								<?php echo esc_attr( $sitewide_sale->get_landing_page_visits() ); ?>
+							</td>
+							<td>
+								<?php echo esc_attr( $sitewide_sale->get_checkout_conversions() ); ?>
+							</td>
+							<td>
+								<?php echo esc_attr( $sitewide_sale->get_revenue() ); ?>
+							<td>
+						</tr>
+					<?php
+					$ret[$sitewide_sale->get_id()] = SWSales_Reports::build_chart_data($sitewide_sale);
+				} ?>
+				</tbody>
+			</table>
 
-			$daily_revenue_chart_data = apply_filters( 'swsales_daily_revenue_chart_data', $date_array, $sitewide_sale );
-
-			// Get the best day to highlight in the chart.
-			$highest_daily_revenue = max( $daily_revenue_chart_data );
-			if ( $highest_daily_revenue > 0 ) {
-				$highest_daily_revenue_key = array_search( $highest_daily_revenue, $daily_revenue_chart_data );
-			}
-
+	<?php
 			// Display the chart.
-			if ( is_array( $daily_revenue_chart_data ) ) { ?>
+			if ( is_array( $ret ) ) { ?>
 				<hr>
-				<div class="swsales_chart_area">
+					<h3><?php esc_html_e( 'Revenue by Day', 'sitewide-sales' ); ?></h3>
 					<div id="chart_div"></div>
-					<?php if ( count( $date_array_all ) > $daily_revenue_chart_days ) { ?>
-						<div class="swsales_chart_description"><p><center><em>
-							<?php esc_html_e( sprintf( __( 'This chart shows the last %s days of sale performance.', 'sitewide-sales' ), $daily_revenue_chart_days ) ); ?>
-						</em></center></p></div>
-					<?php } ?>
 				</div> <!-- end swsales_chart_area -->
 				<script>
+					jQuery(document).ready(function($) {
+
+						$('#swsales_select_report_left, #swsales_select_report_right').on('change', evt => {
+							$changed = $(evt.target);
+							$changed.closest('form').submit();
+						});
+
+					});
 					// Draw the chart.
 					google.charts.load('current', {'packages':['corechart']});
 					google.charts.setOnLoadCallback(drawVisualization);
 					function drawVisualization() {
-						var dataTable = new google.visualization.DataTable();
-						dataTable.addColumn('string', <?php echo wp_json_encode( esc_html__( 'DAY', 'sitewide-sales' ) ); ?>);
-						dataTable.addColumn('number', <?php echo wp_json_encode( esc_html__( 'Sale Revenue', 'sitewide-sales' ) ); ?>);
+						const dataTable = new google.visualization.DataTable();
+						dataTable.addColumn('string', <?php echo wp_json_encode( esc_html__( 'Sale Day', 'sitewide-sales' ) ); ?>);
+						dataTable.addColumn('number', <?php echo wp_json_encode( esc_html( $sale1->get_name(),  'sitewide-sales' ) ); ?>);
+						<?php if( count( $sitewide_sales ) > 1 ) { ?>
+							dataTable.addColumn('number', <?php echo wp_json_encode( esc_html( $sale2->get_name(), 'sitewide-sales' ) ); ?>);
+						<?php }?>
 						dataTable.addColumn({type: 'string', role: 'style'});
 						dataTable.addColumn({type: 'string', role: 'annotation'});
 						dataTable.addRows([
-							<?php foreach( $daily_revenue_chart_data as $date => $value ) { ?>
-								[
-									<?php
-										echo wp_json_encode( esc_html( date_i18n( get_option('date_format'), strtotime( $date ) ) ) );
-									?>,
-									<?php echo wp_json_encode( (int) $value ); ?>,
-									<?php
-										if ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {
-											echo wp_json_encode( 'color: #5EC16C;' );
-										} else {
-											echo wp_json_encode( '' );
-										}
-									?>,
-									<?php
-										if ( ! empty( $highest_daily_revenue_key ) && $date === $highest_daily_revenue_key ) {
-											echo wp_json_encode( esc_html__( 'Best Day', 'sitewide-sales' ) );
-										} elseif ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {
-											echo wp_json_encode( esc_html__( 'Today', 'sitewide-sales' ) );
-										} else {
-											echo wp_json_encode( '' );
-										}
-									?>,
-								],
-							<?php } ?>
+							<?php 
+								
+									$data = $ret[$sale1->get_id()];
+									$daily_revenue_chart_data = $data['daily_revenue_chart_data'];
+									$date_array_all = $data['date_array_all'];
+									$highest_daily_revenue_key = $data['highest_daily_revenue_key'];
+									$daily_revenue_chart_days = $data['daily_revenue_chart_days'];
+									foreach( $daily_revenue_chart_data as $date => $value ) { ?>
+									[
+										<?php
+											echo wp_json_encode( esc_html( date_i18n( get_option('date_format'), strtotime( $date ) ) ) );
+										?>,
+										<?php echo wp_json_encode( (int) $value ); ?>,
+										<?php if( count( $sitewide_sales ) > 1 ) {
+											$revenue_to_compare = isset( $ret[$sale2->get_id()]['daily_revenue_chart_data'][$date] ) ? 
+											$ret[$sale2->get_id()]['daily_revenue_chart_data'][$date] : 0;
+												echo wp_json_encode( (int) $revenue_to_compare );
+											?>,
+										<?php }?>,
+										<?php
+											if ( ! empty( $highest_daily_revenue_key ) && $date === $highest_daily_revenue_key ) {
+												echo wp_json_encode( esc_html__( 'Best Day', 'sitewide-sales' ) );
+											} elseif ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {
+												echo wp_json_encode( esc_html__( 'Today', 'sitewide-sales' ) );
+											} else {
+												echo wp_json_encode( '' );
+											}
+										?>,
+									],
+						<?php   }
+							// }
+						?>
 						]);
-						var options = {
-							title: swsales_report_title(),
-							titlePosition: 'top',
-							titleTextStyle: {
-								color: '#555555',
+						const options = {
+							colors: ['#DC5D36', '#0D3D54'],
+							legend: {
+								position: 'top',
+								alignment:'center'
 							},
-							legend: {position: 'none'},
-							colors: ['#31825D'],
+							height: 600,
 							chartArea: {
-								width: '90%',
+								width: '80%',
 							},
+
 							hAxis: {
 								textStyle: {
 									color: '#555555',
@@ -234,7 +292,6 @@ class SWSales_Reports {
 							},
 							vAxis: {
 								textStyle: {
-									color: '#555555',
 									fontSize: '12',
 									italic: false,
 								},
@@ -256,27 +313,30 @@ class SWSales_Reports {
 						);
 						$daily_revenue_chart_currency_format = apply_filters( 'swsales_daily_revenue_chart_currency_format', $daily_revenue_chart_currency_format, $sitewide_sale );
 						?>
-						var formatter = new google.visualization.NumberFormat({
+						const formatter = new google.visualization.NumberFormat({
 							'<?php echo esc_html( $daily_revenue_chart_currency_format['position'] );?>': '<?php echo esc_html( html_entity_decode( $daily_revenue_chart_currency_format['currency_symbol'] ) ); ?>',
 							'decimalSymbol': '<?php echo esc_html( html_entity_decode( $daily_revenue_chart_currency_format['decimal_separator'] ) ); ?>',
 							'fractionDigits': <?php echo intval( $daily_revenue_chart_currency_format['decimals'] ); ?>,
 							'groupingSymbol': '<?php echo esc_html( html_entity_decode( $daily_revenue_chart_currency_format['thousands_separator'] ) ); ?>',
 						});
 						formatter.format(dataTable, 1);
+						<?php if( count( $sitewide_sales ) > 1 ) { ?>
+							formatter.format(dataTable, 2);
+						<?php }?>
 
-						var chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
+
+						const chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
 						chart.draw(dataTable, options);
 					}
 
 					function swsales_report_title() {
-						return <?php echo wp_json_encode( esc_html( sprintf( __( 'Sale Revenue by Day for %s to %s.', 'sitewide-sales' ), $sitewide_sale->get_start_date(), $sitewide_sale->get_end_date() ) ) ); ?>;
+						return <?php echo wp_json_encode( esc_html( sprintf( __( 'Revenue by Day', 'sitewide-sales' ) ) ) ); ?>;
 					}
 
 				</script>
 				<?php
 			}
 			?>
-		</div>
 		<?php
 		do_action( 'swsales_additional_reports', $sitewide_sale );
 	}

--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -153,6 +153,26 @@ class SWSales_Sitewide_Sale {
 	}
 
 	/**
+	 * Returns an Array containing the corresponding Sitewide Sale objects.
+	 *
+	 * @param Array $ids A set of SWSales_Sitewide_Sale ids to get.
+	 * @return Array An array containing SWSales_Sitewide_Sale objects.
+	 * @since TBD.
+	 */
+	public static function get_sitewide_sales( $ids ) {
+		if( !is_array($ids) ) 
+			return;
+		
+
+		$sales = array();
+		foreach ( $ids as $id ) {
+			$sales[] = self::get_sitewide_sale( $id );
+		}	
+
+		return $sales;
+	}
+
+	/**
 	 * -----------------------------
 	 * GETTER FUNCTIONS (POST META)
 	 * -----------------------------

--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -560,20 +560,86 @@ class SWSales_Sitewide_Sale {
 	 * Returns the number of checkouts which used the sale's discount code/coupon.
 	 * Must be filtered by the sale's module, otherwise just shows N/A.
 	 *
-	 * @return string
+	 * @param bool formatted whether to format the revenue.
+	 * @return string number of checkouts using sale code.
 	 */
-	public function get_checkout_conversions() {
-		return apply_filters( 'swsales_get_checkout_conversions', 'N/A', $this );
+	public function get_checkout_conversions($formatted = false) {
+		return apply_filters( 'swsales_get_checkout_conversions', 'N/A', $this, $formatted );
 	}
 
 	/**
 	 * Returns the revenue generated during the sale period.
 	 * Must be filtered by the sale's module, otherwise just shows N/A.
 	 *
-	 * @return string
+	 * @param bool formatted whether to format the revenue.
+	 * @return string revenue from sale.
+	 * @since TBD
 	 */
-	public function get_revenue() {
-		return apply_filters( 'swsales_get_revenue', 'N/A', $this );
+	public function get_revenue($formatted = false) {
+		return apply_filters( 'swsales_get_revenue', 'N/A', $this, $formatted );
+	}
+
+	/**
+	 * Returns the revenue generated during the sale period from sales using the sale's discount code/coupon.
+	 * Must be filtered by the sale's module, otherwise just shows N/A.
+	 *
+	 * @param bool formatted whether to format the revenue.
+	 * @return string revenue from sale code.
+	 * since TBD
+	 */
+	public function get_other_revenue($formatted = false) {
+		return apply_filters( 'swsales_get_other_revenue', 'N/A', $this, $formatted );
+	}
+
+	/**
+	 * Return revenue from renewals during the sale period.
+	 * Must be filtered by the sale's module, otherwise just shows N/A.
+	 *
+	 * @param bool formatted whether to format the revenue.
+	 * @return string revenue from renewals.
+	 * @since TBD
+	 */
+	public function get_renewal_revenue($formatted = false) {
+		return apply_filters( 'swsales_get_renewal_revenue','N/A', $this, $formatted );
+	}
+
+	/**
+	 * Gets total revenue from the sale period.
+	 *
+	 * @param bool formatted whether to format the revenue.
+	 * @return string total revenue
+	 * @since TBD
+	 */
+	public function get_total_revenue($formatted = false) {
+		return apply_filters( 'swsales_get_total_revenue', 'N/A', $this, $formatted );
+	}
+
+	/**
+	 * Gets an array with revenue by day.
+	 *
+	 * @param bool formatted whether to format the revenue.
+	 * @return array revenue by day
+	 * @since TBD
+	 */
+	public function get_daily_revenue($formatted = false) {
+			// Daily Revenue Chart.
+			// Build an array with each day of sale as a key to store revenue data in.
+			$date_array_all = array();
+			$period = new \DatePeriod(
+				new \DateTime( $this->get_start_date( 'Y-m-d' ) ),
+				new \DateInterval('P1D'),
+				new \DateTime( $this->get_end_date( 'Y-m-d' ) . ' + 1 day' )
+			);
+			foreach ($period as $key => $value) {
+				$date_array_all[ $value->format('Y-m-d') ] = 0.0;
+			}
+
+			/**
+			 * Filter the number of days shown in the report chart. Defauly is 31 days.
+			 */
+			$daily_revenue_chart_days = (int) apply_filters( 'swsales_daily_revenue_chart_days', '31' );
+			$date_array = array_slice( $date_array_all, ( $daily_revenue_chart_days * -1 ), $daily_revenue_chart_days, true );
+		return apply_filters( 'swsales_daily_revenue_chart_data', 'N/A', $date_array, $this, $formatted );
 	}
 
 	/**

--- a/css/admin.css
+++ b/css/admin.css
@@ -181,6 +181,46 @@
 	padding: 2rem;
 	text-align: center;
 }
+
+.swsales_reports-box table.reports-comparison-table-above-chart,
+.swsales_reports-box table.reports-comparison-table-below-chart {
+	width: 100%;
+}
+.swsales_reports-box table.reports-comparison-table-above-chart .dashicons-arrow-up-alt2,
+.swsales_reports-box table.reports-comparison-table-above-chart .sale-rate.swsales_growth {
+	color: green;
+	font-weight: 400;
+	font-size: 16px;
+	vertical-align: top;
+}
+
+.swsales_reports-box table.reports-comparison-table-above-chart .sale-rate.swsales_decline,
+.swsales_reports-box table.reports-comparison-table-above-chart .sale-rate .dashicons-arrow-down-alt2 {
+	color: red;
+	font-weight: 400;
+	font-size: 16px;
+	vertical-align: top;
+}
+
+.swsales_reports-box table.reports-comparison-table-above-chart th,
+.swsales_reports-box table.reports-comparison-table-below-chart th,
+.swsales_reports-box table.reports-comparison-table-above-chart td.sale_name,
+.swsales_reports-box table.reports-comparison-table-below-chart th	 {
+	color: #000;
+	font-family: "Open Sans", serif;
+	font-weight:400;
+	font-size: 20px;
+}
+.swsales_reports-box table.reports-comparison-table-above-chart td {
+	padding: 15px 0;
+}
+.swsales_reports-box table.reports-comparison-table-above-chart td.sale_numbers {
+	font-size: 30px;
+	color: #000;
+	font-family: "Open Sans", serif;
+	font-weight: 700;
+}
+
 .post-type-pmpro_sitewide_sale .swsales_reports-box {
 	border: none;
 	margin: 0;
@@ -205,8 +245,7 @@
 .swsales_reports-data-4col {
 	grid-template-columns: 1fr 1fr 1fr 1fr;
 }
-.swsales_reports-data-section {
-}
+
 .swsales_reports-data-section h1 {
 	font-size: 30px;
 	line-height: 40px;

--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -563,43 +563,7 @@ class SWSales_Module_EDD {
 
 		$new_rev_without_code = $total_rev - $new_rev_with_code;
 
-		?>
-		<div class="swsales_reports-box">
-			<h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-			<p>
-				<?php
-				printf(
-					wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
-					$sitewide_sale->get_start_date(),
-					$sitewide_sale->get_end_date()
-				);
-				?>
-			</p>
-			<hr />
-			<div class="swsales_reports-data swsales_reports-data-3col">
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_with_code ) ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_without_code ) ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $total_rev ) ) ) ); ?></h1>
-					<p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
-				</div>
-			</div>
-		</div>
-		<?php
+		require_once ( SWSALES_DIR . '/modules/partials/revenue_breakdown_partial.php' );
 	}
 
 	/**
@@ -822,53 +786,8 @@ class SWSales_Module_EDD {
 		
 		$total_rev = $new_rev_without_code + $new_rev_with_code + $total_renewals;
 
-		?>
-		<div class="swsales_reports-box">
-			<h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-			<p>
-				<?php
-				printf(
-					wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
-					$sitewide_sale->get_start_date(),
-					$sitewide_sale->get_end_date()
-				);
-				?>
-			</p>
-			<hr />
-			<div class="swsales_reports-data swsales_reports-data-<?php echo empty( $total_renewals ) ? 3 : 4 ?>col">
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_with_code ) ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_without_code ) ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<?php if ( ! empty( $total_renewals ) ) { ?>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $total_renewals ) ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Renewals', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $total_renewals / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<?php } ?>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $total_rev ) ) ) ); ?></h1>
-					<p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
-				</div>
-			</div>
-		</div>
-		<?php
+		require_once ( SWSALES_DIR . '/modules/partials/revenue_breakdown_partial.php' );
+		
 	}
 }
 SWSales_Module_EDD::init();

--- a/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
+++ b/modules/ecommerce/pmpro/class-swsales-module-pmpro.php
@@ -982,51 +982,9 @@ class SWSales_Module_PMPro {
 			)
 		);
 
-		?>
-		<div class="swsales_reports-box">
-			<h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-			<p>
-				<?php
-				printf(
-					wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
-					$sitewide_sale->get_start_date(),
-					$sitewide_sale->get_end_date()
-				);
-				?>
-			</p>
-			<hr />
-			<div class="swsales_reports-data swsales_reports-data-4col">
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( pmpro_formatPrice( $new_rev_with_code ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( pmpro_formatPrice( $new_rev_without_code ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( pmpro_formatPrice( $renewals ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Renewals', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $renewals / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( pmpro_formatPrice( $total_rev ) ); ?></h1>
-					<p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
-				</div>
-			</div>
-		</div>
-		<?php
+		require_once ( SWSALES_DIR . '/modules/partials/revenue_breakdown_partial.php' );
+
+
 	}
 
 }

--- a/modules/ecommerce/wc/class-swsales-module-wc.php
+++ b/modules/ecommerce/wc/class-swsales-module-wc.php
@@ -671,53 +671,8 @@ class SWSales_Module_WC {
 		}
 		$new_rev_without_code = $total_rev - $new_rev_with_code - $renewals;
 
-		?>
-		<div class="swsales_reports-box">
-			<h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-			<p>
-				<?php
-				printf(
-					wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
-					$sitewide_sale->get_start_date(),
-					$sitewide_sale->get_end_date()
-				);
-				?>
-			</p>
-			<hr />
-			<div class="swsales_reports-data swsales_reports-data-<?php echo empty( $renewals ) ? 3 : 4 ?>col">
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( wc_price( $new_rev_with_code ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( wc_price( $new_rev_without_code ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<?php if ( ! empty( $renewals ) ) { ?>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( wc_price( $renewals ) ) ); ?></h1>
-					<p>
-						<?php esc_html_e( 'Renewals', 'sitewide-sales' ); ?>
-						<br />
-						(<?php echo( esc_html( 0 == $renewals ? 'NA' : round( ( $renewals / $total_rev ) * 100, 2 ) ) ); ?>%)
-					</p>
-				</div>
-				<?php } ?>
-				<div class="swsales_reports-data-section">
-					<h1><?php echo esc_attr( wp_strip_all_tags( wc_price( $total_rev ) ) ); ?></h1>
-					<p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
-				</div>
-			</div>
-		</div>
-		<?php
+		require_once ( SWSALES_DIR . '/modules/partials/revenue_breakdown_partial.php' );
+
 	}
 
 }

--- a/modules/partials/revenue_breakdown_partial.php
+++ b/modules/partials/revenue_breakdown_partial.php
@@ -71,6 +71,3 @@ if(! is_array( $sitewide_sales ) ) {
         </tbody>
     </table>
 </div>
-
-function format
-	

--- a/modules/partials/revenue_breakdown_partial.php
+++ b/modules/partials/revenue_breakdown_partial.php
@@ -1,0 +1,47 @@
+<div class="swsales_reports-box">
+    <h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
+    <p> 
+        <?php
+        printf(
+            wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
+            $sitewide_sale->get_start_date(),
+            $sitewide_sale->get_end_date()
+        );
+        ?>
+    </p>
+    <hr />
+    <div class="swsales_reports-data swsales_reports-data-3col">
+        <div class="swsales_reports-data-section">
+            <h1><?php echo esc_attr( wp_strip_all_tags( get_revenue_by_module( $new_rev_with_code) ) );//edd_currency_filter( edd_format_amount( $new_rev_with_code ) ) ) ); ?></h1>
+            <p>
+                <?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
+                <br />
+                (<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
+            </p>
+        </div>
+        <div class="swsales_reports-data-section">
+            <h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_without_code ) ) ) ); ?></h1>
+            <p>
+                <?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
+                <br />
+                (<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
+            </p>
+        </div>
+        <div class="swsales_reports-data-section">
+            <h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $total_rev ) ) ) ); ?></h1>
+            <p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
+        </div>
+    </div>
+</div>
+
+<?php
+
+function get_revenue_by_module($rev) {
+    switch( get_class()) {
+        case 'a':
+        break;
+        default:
+    
+    }
+}
+	

--- a/modules/partials/revenue_breakdown_partial.php
+++ b/modules/partials/revenue_breakdown_partial.php
@@ -1,47 +1,76 @@
-<div class="swsales_reports-box">
-    <h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-    <p> 
-        <?php
-        printf(
-            wp_kses_post( 'All orders from %s to %s.', 'sitewide-sales' ),
-            $sitewide_sale->get_start_date(),
-            $sitewide_sale->get_end_date()
-        );
-        ?>
-    </p>
-    <hr />
-    <div class="swsales_reports-data swsales_reports-data-3col">
-        <div class="swsales_reports-data-section">
-            <h1><?php echo esc_attr( wp_strip_all_tags( get_revenue_by_module( $new_rev_with_code) ) );//edd_currency_filter( edd_format_amount( $new_rev_with_code ) ) ) ); ?></h1>
-            <p>
-                <?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
-                <br />
-                (<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_with_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-            </p>
-        </div>
-        <div class="swsales_reports-data-section">
-            <h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $new_rev_without_code ) ) ) ); ?></h1>
-            <p>
-                <?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
-                <br />
-                (<?php echo( esc_html( 0 == $total_rev ? 'NA' : round( ( $new_rev_without_code / $total_rev ) * 100, 2 ) ) ); ?>%)
-            </p>
-        </div>
-        <div class="swsales_reports-data-section">
-            <h1><?php echo esc_attr( wp_strip_all_tags( edd_currency_filter( edd_format_amount( $total_rev ) ) ) ); ?></h1>
-            <p><?php esc_html_e( 'Total Revenue in Period', 'sitewide-sales' ); ?></p>
-        </div>
-    </div>
-</div>
-
 <?php
-
-function get_revenue_by_module($rev) {
-    switch( get_class()) {
-        case 'a':
-        break;
-        default:
-    
+//Bail if param it's not an array
+if(! is_array( $sitewide_sales ) ) {
+    if ( ! is_a( $sitewide_sales, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' )) {
+        return;
+    }
+    //somehow do_action filter converts the array into a single object, so let's wrap in an array again.
+    $sitewide_sales = array( $sitewide_sales );
+} else {
+    // Bail if given elements aren't SWSales_Sitewide_Sale objects.
+    foreach ($sitewide_sales as $sitewide_sale) {
+        if ( ! is_a( $sitewide_sale, 'Sitewide_Sales\classes\SWSales_Sitewide_Sale' ) ) {
+            return;
+        }
+    }
+    // Bail if the array comes empty
+    if( count( $sitewide_sales ) < 1) {
+        return;
     }
 }
+
+?>
+
+<div class="swsales_reports-box">
+    <h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
+    <table>
+        <tr>
+            <th>
+            </th>
+            <th>
+                <?php esc_html_e( 'Sale Revenue', 'sitewide-sales' ); ?>
+            </th>
+            <th>
+                <?php esc_html_e( 'Other New Revenue', 'sitewide-sales' ); ?>
+            </th>
+
+            <?php if ( $sitewide_sales[0]->get_sale_type() == 'pmpro' ) { ?>
+                <th>
+                    <?php esc_html_e( 'Renewals', 'sitewide-sales' ); ?>
+                </th>
+            <?php } ?>
+            <th>
+                <?php esc_html_e( 'Total new revenue in Period', 'sitewide-sales' ); ?>
+            </th>
+        </tr>
+        <tbody>
+        <?php foreach ($sitewide_sales as $sitewide_sale) { ?>
+            <tr>
+                <td>
+                    <?php echo esc_html( $sitewide_sale->get_name() ); ?>
+                </td>
+                <td>
+                    <?php echo esc_html( $sitewide_sale->get_revenue(true) ); ?>
+                </td>
+                <td>
+                    <?php echo esc_html( $sitewide_sale->get_other_revenue(true) ); ?>
+                </td>
+                <?php if ( $sitewide_sales[0]->get_sale_type() == 'pmpro' ) { ?>
+                    <td>
+                        <?php if ( $sitewide_sale->get_sale_type() == 'pmpro' ) {
+                                echo esc_html( $sitewide_sale->get_renewal_revenue() );
+                            }
+                        ?>
+                    </td>
+                <?php } ?>
+                <td>
+                    <?php echo esc_html( $sitewide_sale->get_total_revenue() ); ?>
+                </td>
+            </tr>
+        <?php } ?>
+        </tbody>
+    </table>
+</div>
+
+function format
 	

--- a/modules/partials/revenue_breakdown_partial.php
+++ b/modules/partials/revenue_breakdown_partial.php
@@ -23,7 +23,7 @@ if(! is_array( $sitewide_sales ) ) {
 
 <div class="swsales_reports-box">
     <h1 class="swsales_reports-box-title"><?php esc_html_e( 'Revenue Breakdown', 'sitewide-sales' ); ?></h1>
-    <table>
+    <table class="reports-comparison-table-below-chart">
         <tr>
             <th>
             </th>


### PR DESCRIPTION
 * Make dropdown form an array to support passing two sales.
 * Add a function in the Sales class to fetch an array
 * Modify Reports class to support 3 different flows. No Sale selected, one sale selected, two sales selected.
 * Add a partial to abstract revenue breakdown report block.
 * Require from each module.
 
 
 
![image](https://github.com/strangerstudios/sitewide-sales/assets/1678457/ddea589b-4ddd-49c2-8e4e-df635f55c8ad)


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
