### PR TITLE
Fixing preview sale links when modified href attr via JS

### DIFF
--- a/js/swsales-cpt-meta.js
+++ b/js/swsales-cpt-meta.js
@@ -34,9 +34,9 @@ jQuery( document ).ready(
 			} else {
 				$( '#swsales_edit_landing_page' ).attr( 'href', swsales.admin_url + 'post.php?post=' + landing_page_id + '&action=edit' );
 				$( '#swsales_view_landing_page' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id );
-				$( '#swsales_view_landing_page_pre_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id );
-				$( '#swsales_view_landing_page_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id );
-				$( '#swsales_view_landing_page_post_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id );
+				$( '#swsales_view_landing_page_pre_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id + '&swsales_preview_time_period=pre-sale' );
+				$( '#swsales_view_landing_page_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id + '&swsales_preview_time_period=sale' );
+				$( '#swsales_view_landing_page_post_sale' ).attr( 'href', swsales.home_url + '?page_id=' + landing_page_id + '&swsales_preview_time_period=post-sale' );
 				if ( swsales.pages_with_shortcodes == null ) {
 					swsales.pages_with_shortcodes = [];
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When the JS updates the href attribute of the three preview links on dropdown change, the attribute for sale period was getting lost. This makes sure that attribute is preserved.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
