### PR TITLE
Fix for admin sale banner previews

### DIFF
--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -563,9 +563,10 @@ class SWSales_Sitewide_Sale {
 			return ( $this->is_active_sitewide_sale() && 'sale' === $this->get_time_period() );
 		}
 
-		// Allow admins to preview the sale period and banners regardless of whether sale is hidden using a URL attribute.
+		// Allow admins to preview the sale period and banners.
+		// This logic shows banner or landing page content regardless of whether sale is 'active' or in the 'sale' period.
 		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_time_period'] ) || isset( $_REQUEST['swsales_preview_sale_banner'] ) ) {
-			return ( $this->is_active_sitewide_sale() && 'sale' === $this->get_time_period() );
+			return true;
 		}
 
 		// If the sale is hidden for this user, return.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The logic to allow admins to preview sale banners and landing pages (by period defined in the URL Attribute) was not working as intended. Sale banners specifically could not be viewed unless the sale was active and in the period "sale" (meaining was between the start and end date of the sale). We want admins to be able to preview at any time, whether the sale is over or upcoming.