### PR TITLE
Adjusting logic to allow admins to preview sales even when sale is no…

### DIFF
--- a/classes/class-swsales-sitewide-sale.php
+++ b/classes/class-swsales-sitewide-sale.php
@@ -565,7 +565,7 @@ class SWSales_Sitewide_Sale {
 
 		// Allow admins to preview the sale period and banners.
 		// This logic shows banner or landing page content regardless of whether sale is 'active' or in the 'sale' period.
-		if ( current_user_can( 'administrator' ) && isset( $_REQUEST['swsales_preview_time_period'] ) || isset( $_REQUEST['swsales_preview_sale_banner'] ) ) {
+		if ( current_user_can( 'administrator' ) && ( isset( $_REQUEST['swsales_preview_time_period'] ) || isset( $_REQUEST['swsales_preview_sale_banner'] ) ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
…t the active one

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The JS for sale tracking is required to "display" a banner (using JS to show the banner and remove the display: none inline style. That JS was not being enqueued in cases where the admin was previewing the banner (unless that preview banner was the "active" sale in settings.

This update checks for the user role + presence of the URL attribute to preview the banner and assigns that previewed sale ID to the active sale.

Then falls back to check if there's an active sale in settings.

Then returns if no sales are found.

This also fixes a bug in the logic to ensure that the user is admin + one of the two URL parameters are set in order to flag the sale as "running".
