### PR TITLE
Fixing fatal error if $primary_sale_chart_data is null

### DIFF
--- a/classes/class-swsales-reports.php
+++ b/classes/class-swsales-reports.php
@@ -317,12 +317,6 @@ class SWSales_Reports {
 				}
 			}
 
-			// Get the best day for primary sale to highlight in the chart.
-			$highest_daily_revenue = max( $primary_sale_chart_data );
-			if ( $highest_daily_revenue > 0 ) {
-				$highest_daily_revenue_key = array_search( $highest_daily_revenue, $primary_sale_chart_data );
-			}
-
 			// Display the chart.
 			if ( is_array( $primary_sale_chart_data ) ) { ?>
 				<div id="swsales_sale_revenue_by_day" class="swsales_reports-box swsales_chart_area">
@@ -364,6 +358,11 @@ class SWSales_Reports {
 										}
 									?>,
 									<?php
+										// Get the best day for primary sale to highlight in the chart.
+										$highest_daily_revenue = max( $primary_sale_chart_data );
+										if ( $highest_daily_revenue > 0 ) {
+											$highest_daily_revenue_key = array_search( $highest_daily_revenue, $primary_sale_chart_data );
+										}
 										if ( ! empty( $highest_daily_revenue_key ) && $date === $highest_daily_revenue_key ) {
 											echo wp_json_encode( esc_html__( 'Best Day', 'sitewide-sales' ) );
 										} elseif ( date( 'd.m.Y' ) === date( 'd.m.Y', strtotime( $date ) ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing error `PHP Fatal error: Uncaught TypeError: max(): Argument #1 ($value) must be of type array, null given in /.../sitewide-sales/classes/class-swsales-reports.php:321`
