### PR TITLE
Fix 'Invalid nonce' error on EDD edit discount code link

### DIFF
--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -140,7 +140,7 @@ class SWSales_Module_EDD {
 							<span id="swsales_edd_after_coupon_select">
 							<?php
 							if ( false !== $coupon_found ) {
-								$edit_coupon_url = admin_url( 'edit.php?post_type=download&page=edd-discounts&edd-action=edit_discount&discount='.$coupon_found->id );
+								$edit_coupon_url = admin_url( 'edit.php?post_type=download&page=edd-discounts&view=edit_discount&discount=' . $coupon_found->id );
 							} else {
 								$edit_coupon_url = '#';
 							}

--- a/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
+++ b/modules/ecommerce/edd/swsales-module-edd-metaboxes.js
@@ -11,7 +11,7 @@ jQuery( document ).ready(
 			if (coupon_id == 0) {
 				$( '#swsales_edd_after_coupon_select' ).hide();
 			} else {
-				$( '#swsales_edd_edit_coupon' ).attr( 'href', swsales_edd_metaboxes.admin_url + 'edit.php?post_type=download&page=edd-discounts&edd-action=edit_discount&discount=' + coupon_id );
+				$( '#swsales_edd_edit_coupon' ).attr( 'href', swsales_edd_metaboxes.admin_url + 'edit.php?post_type=download&page=edd-discounts&view=edit_discount&discount=' + coupon_id );
 				$( '#swsales_edd_after_coupon_select' ).show();
 			}
 		}


### PR DESCRIPTION
## Summary

- The "edit discount code" link on the Sitewide Sale edit page used `edd-action=edit_discount`, which triggers EDD's discount save handler and requires nonce validation
- The correct URL parameter for viewing the edit screen is `view=edit_discount`, which simply loads the editor without requiring a nonce
- Fixed in both the PHP template (server-rendered link) and the JavaScript (dynamically-updated link when changing the dropdown)

Fixes #183

## Test plan

- [ ] Create or edit a Sitewide Sale with EDD sale type
- [ ] Select an existing EDD discount code
- [ ] Click the "edit discount code" link — should open EDD discount edit page
- [ ] Change the selected discount code in the dropdown, then click "edit discount code" — the dynamically-updated link should also work