### PR TITLE
Skip auto-applying EDD discount when product requirements aren't met

### DIFF
--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -299,8 +299,13 @@ class SWSales_Module_EDD {
 
 			$code = new \EDD_Discount( $discount_code_id );
 	 		if ( !empty( $code ) && empty( $_REQUEST['discount'] ) ) {
+				// Skip if the discount's product requirements aren't met for the current cart.
+				if ( edd_get_cart_contents() && ! $code->is_product_requirements_met( false ) ) {
+					return;
+				}
+
  				//Set it in the $_REQUEST and EDD Session as the EDD init runs at priority 0
-	 			$_REQUEST['discount'] = $code->code;		 			
+	 			$_REQUEST['discount'] = $code->code;
 	 			EDD()->session->set( 'preset_discount', $code->code );
 	 		} 
 		}		 		

--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -299,8 +299,11 @@ class SWSales_Module_EDD {
 
 			$code = new \EDD_Discount( $discount_code_id );
 	 		if ( !empty( $code ) && empty( $_REQUEST['discount'] ) ) {
-				// At checkout, skip if the discount's product requirements aren't met for the current cart.
-				if ( edd_is_checkout() && edd_get_cart_contents() && ! $code->is_product_requirements_met( false ) ) {
+				// If there's a cart, check product requirements before applying.
+				if ( edd_get_cart_contents() && ! $code->is_product_requirements_met( false ) ) {
+					// Remove the discount if it was previously applied (e.g., before a Lifetime product was added to cart).
+					edd_unset_cart_discount( $code->code );
+					EDD()->session->set( 'preset_discount', null );
 					return;
 				}
 

--- a/modules/ecommerce/edd/class-swsales-module-edd.php
+++ b/modules/ecommerce/edd/class-swsales-module-edd.php
@@ -299,8 +299,8 @@ class SWSales_Module_EDD {
 
 			$code = new \EDD_Discount( $discount_code_id );
 	 		if ( !empty( $code ) && empty( $_REQUEST['discount'] ) ) {
-				// Skip if the discount's product requirements aren't met for the current cart.
-				if ( edd_get_cart_contents() && ! $code->is_product_requirements_met( false ) ) {
+				// At checkout, skip if the discount's product requirements aren't met for the current cart.
+				if ( edd_is_checkout() && edd_get_cart_contents() && ! $code->is_product_requirements_met( false ) ) {
 					return;
 				}
 


### PR DESCRIPTION
## Summary

- When Sitewide Sales auto-applies an EDD discount via `automatic_coupon_application()`, it now checks if the cart contents satisfy the discount's product requirements before applying
- If requirements aren't met (e.g., lifetime products in cart with an annual-only discount), the discount is silently skipped instead of being applied and then rejected by EDD with a confusing "product requirements not met" error
- Uses EDD's own `is_product_requirements_met(false)` — the `false` parameter suppresses error messages in the session

## Test plan

- [ ] Configure a Sitewide Sale with an EDD discount that has product requirements (e.g., only annual price IDs)
- [ ] Add a product/price that IS in the requirements — discount should auto-apply normally
- [ ] Add a product/price that is NOT in the requirements (e.g., lifetime) — discount should be silently skipped, no error shown
- [ ] With an empty cart, visit the site — no errors, discount ready to apply when eligible items are added
- [ ] Verify the discount still auto-applies correctly on the landing page with eligible products